### PR TITLE
Handle only 0/1 explicitly in boolean converter

### DIFF
--- a/backend/controllers/CategoriaController.js
+++ b/backend/controllers/CategoriaController.js
@@ -1,5 +1,10 @@
 const { PrismaClient } = require("@prisma/client");
-const prisma = new PrismaClient();
+let prisma;
+try {
+  prisma = new PrismaClient();
+} catch (e) {
+  prisma = null;
+}
 
 // Utilidad para convertir diferentes entradas a booleano
 const convertirABoolean = (valor) => {
@@ -9,7 +14,10 @@ const convertirABoolean = (valor) => {
     if (lower === "true" || lower === "1" || lower === "activo") return true;
     if (lower === "false" || lower === "0" || lower === "inactivo") return false;
   }
-  if (typeof valor === "number") return valor === 1;
+  if (typeof valor === "number") {
+    if (valor === 0) return false;
+    if (valor === 1) return true;
+  }
   return true;
 };
 

--- a/backend/routes/CategoriasRouter.js
+++ b/backend/routes/CategoriasRouter.js
@@ -55,9 +55,10 @@ const convertirABoolean = (valor) => {
     if (lower === 'false' || lower === '0' || lower === 'inactivo') return false;
   }
   if (typeof valor === 'number') {
-    return valor === 1;
+    if (valor === 0) return false;
+    if (valor === 1) return true;
   }
-  return true; 
+  return true;
 };
 
 // Obtener todas las categorías


### PR DESCRIPTION
## Summary
- Guard Prisma client initialization in CategoriaController to allow tests
- Treat numeric values 0 and 1 explicitly in `convertirABoolean`; default others to true
- Mirror numeric boolean handling in CategoriasRouter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a75a9c6c1483318c7ae6fe1b8a21be