### PR TITLE
Refactor boolean utility and enable Node tests

### DIFF
--- a/backend/controllers/CategoriaController.js
+++ b/backend/controllers/CategoriaController.js
@@ -1,17 +1,7 @@
 const { PrismaClient } = require("@prisma/client");
 const prisma = new PrismaClient();
 
-// Utilidad para convertir diferentes entradas a booleano
-const convertirABoolean = (valor) => {
-  if (typeof valor === "boolean") return valor;
-  if (typeof valor === "string") {
-    const lower = valor.toLowerCase();
-    if (lower === "true" || lower === "1" || lower === "activo") return true;
-    if (lower === "false" || lower === "0" || lower === "inactivo") return false;
-  }
-  if (typeof valor === "number") return valor === 1;
-  return true;
-};
+const { convertirABoolean } = require("../utils/boolean");
 
 // Obtener todas las categorías
 const getCategorias = async (req, res) => {

--- a/backend/middleware/adminMiddleware.js
+++ b/backend/middleware/adminMiddleware.js
@@ -6,7 +6,7 @@ const adminMiddleware = (req, res, next) => {
   const token = authHeader && authHeader.split(' ')[1];
 
   if (!token) {
-    return res.status(401).json({ message: 'No se proveyó un token.' });
+    return res.status(401).json({ message: 'No se proporcionó un token.' });
   }
 
   jwt.verify(token, process.env.JWT_SECRET, (err, decodedPayload) => {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -22,7 +22,6 @@
         "sequelize": "^6.37.7"
       },
       "devDependencies": {
-        "jest": "^30.0.5",
         "nodemon": "^3.1.10",
         "prisma": "^6.13.0",
         "prisma-erd-generator": "^2.0.4"

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "test": "jest"
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",
@@ -25,7 +25,6 @@
     "sequelize": "^6.37.7"
   },
   "devDependencies": {
-    "jest": "^30.0.5",
     "nodemon": "^3.1.10",
     "prisma": "^6.13.0",
     "prisma-erd-generator": "^2.0.4"

--- a/backend/routes/CampanaRouter.js
+++ b/backend/routes/CampanaRouter.js
@@ -14,7 +14,7 @@ const {
 const router = express.Router();
 
 // Crear directorio uploads si no existe
-const uploadsDir = path.join(__dirname, '../../uploads');
+const uploadsDir = path.join(__dirname, '..', 'uploads');
 if (!fs.existsSync(uploadsDir)) {
   fs.mkdirSync(uploadsDir, { recursive: true });
   console.log('📁 Directorio uploads creado:', uploadsDir);
@@ -71,7 +71,7 @@ const handleMulterError = (err, req, res, next) => {
   next(err);
 };
 
-//  Rutas
+// Rutas
 router.get('/', getCampanas);
 router.post('/', upload.single('imagen'), handleMulterError, createCampana);
 router.put('/:id', upload.single('imagen'), handleMulterError, updateCampana);

--- a/backend/tests/convertirABoolean.test.js
+++ b/backend/tests/convertirABoolean.test.js
@@ -1,31 +1,37 @@
-const { convertirABoolean } = require('../controllers/CategoriaController');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { convertirABoolean } = require('../utils/boolean');
 
-describe('convertirABoolean', () => {
-  test('returns same boolean for boolean inputs', () => {
-    expect(convertirABoolean(true)).toBe(true);
-    expect(convertirABoolean(false)).toBe(false);
-  });
-
-  test('converts string "1" and "0"', () => {
-    expect(convertirABoolean('1')).toBe(true);
-    expect(convertirABoolean('0')).toBe(false);
-  });
-
-  test('converts string "activo" and "inactivo"', () => {
-    expect(convertirABoolean('activo')).toBe(true);
-    expect(convertirABoolean('inactivo')).toBe(false);
-  });
-
-  test('converts numeric 1 and 0', () => {
-    expect(convertirABoolean(1)).toBe(true);
-    expect(convertirABoolean(0)).toBe(false);
-  });
-
-  test('returns true for unexpected values', () => {
-    expect(convertirABoolean('yes')).toBe(true);
-    expect(convertirABoolean(null)).toBe(true);
-    expect(convertirABoolean(undefined)).toBe(true);
-    expect(convertirABoolean(2)).toBe(true);
-    expect(convertirABoolean({})).toBe(true);
-  });
+test('returns same boolean for boolean inputs', () => {
+  assert.strictEqual(convertirABoolean(true), true);
+  assert.strictEqual(convertirABoolean(false), false);
 });
+
+test('converts string "1" and "0"', () => {
+  assert.strictEqual(convertirABoolean('1'), true);
+  assert.strictEqual(convertirABoolean('0'), false);
+});
+
+test('converts string "activo" and "inactivo"', () => {
+  assert.strictEqual(convertirABoolean('activo'), true);
+  assert.strictEqual(convertirABoolean('inactivo'), false);
+});
+
+test('converts numeric 1 and 0', () => {
+  assert.strictEqual(convertirABoolean(1), true);
+  assert.strictEqual(convertirABoolean(0), false);
+});
+
+test('is case-insensitive for strings', () => {
+  assert.strictEqual(convertirABoolean('TrUe'), true);
+  assert.strictEqual(convertirABoolean('InAcTiVo'), false);
+});
+
+test('returns false for unexpected values', () => {
+  assert.strictEqual(convertirABoolean('yes'), false);
+  assert.strictEqual(convertirABoolean(null), false);
+  assert.strictEqual(convertirABoolean(undefined), false);
+  assert.strictEqual(convertirABoolean(2), false);
+  assert.strictEqual(convertirABoolean({}), false);
+});
+

--- a/backend/utils/boolean.js
+++ b/backend/utils/boolean.js
@@ -1,0 +1,15 @@
+// Utilidad para convertir diferentes entradas a booleano.
+// Retorna false para valores no reconocidos para evitar activar estados por error.
+const convertirABoolean = (valor) => {
+  if (typeof valor === 'boolean') return valor;
+  if (typeof valor === 'string') {
+    const lower = valor.toLowerCase();
+    if (lower === 'true' || lower === '1' || lower === 'activo') return true;
+    if (lower === 'false' || lower === '0' || lower === 'inactivo') return false;
+  }
+  if (typeof valor === 'number') return valor === 1;
+  return false;
+};
+
+module.exports = { convertirABoolean };
+


### PR DESCRIPTION
## Summary
- Extract boolean conversion helper and default unknown values to false
- Improve campaña routing and middleware wording
- Switch to Node's test runner and expand coverage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a758e0a75483318b3035c38ac6b3cf