### PR TITLE
refactor: centralize boolean conversion utility

### DIFF
--- a/backend/controllers/CategoriaController.js
+++ b/backend/controllers/CategoriaController.js
@@ -1,25 +1,11 @@
 const { PrismaClient } = require("@prisma/client");
+const { convertirABoolean } = require("../utils/boolean");
 let prisma;
 try {
   prisma = new PrismaClient();
 } catch (e) {
   prisma = null;
 }
-
-// Utilidad para convertir diferentes entradas a booleano
-const convertirABoolean = (valor) => {
-  if (typeof valor === "boolean") return valor;
-  if (typeof valor === "string") {
-    const lower = valor.toLowerCase();
-    if (lower === "true" || lower === "1" || lower === "activo") return true;
-    if (lower === "false" || lower === "0" || lower === "inactivo") return false;
-  }
-  if (typeof valor === "number") {
-    if (valor === 0) return false;
-    if (valor === 1) return true;
-  }
-  return true;
-};
 
 // Obtener todas las categorías
 const getCategorias = async (req, res) => {
@@ -232,7 +218,6 @@ const toggleEstadoCategoria = async (req, res) => {
 };
 
 module.exports = {
-  convertirABoolean,
   getCategorias,
   getCategoriaById,
   createCategoria,

--- a/backend/routes/CategoriasRouter.js
+++ b/backend/routes/CategoriasRouter.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fs = require('fs');
 const { PrismaClient } = require('@prisma/client');
 const { updateCategoria } = require('../controllers/CategoriaController');
+const { convertirABoolean } = require('../utils/boolean');
 
 const prisma = new PrismaClient();
 const router = express.Router();
@@ -43,23 +44,6 @@ const upload = multer({
     }
   }
 });
-
-// Función para convertir diferentes tipos de entrada a boolean
-const convertirABoolean = (valor) => {
-  if (typeof valor === 'boolean') {
-    return valor;
-  }
-  if (typeof valor === 'string') {
-    const lower = valor.toLowerCase();
-    if (lower === 'true' || lower === '1' || lower === 'activo') return true;
-    if (lower === 'false' || lower === '0' || lower === 'inactivo') return false;
-  }
-  if (typeof valor === 'number') {
-    if (valor === 0) return false;
-    if (valor === 1) return true;
-  }
-  return true;
-};
 
 // Obtener todas las categorías
 router.get('/', async (req, res) => {

--- a/backend/tests/convertirABoolean.test.js
+++ b/backend/tests/convertirABoolean.test.js
@@ -1,4 +1,4 @@
-const { convertirABoolean } = require('../controllers/CategoriaController');
+const { convertirABoolean } = require('../utils/boolean');
 
 describe('convertirABoolean', () => {
   test('returns same boolean for boolean inputs', () => {

--- a/backend/utils/boolean.js
+++ b/backend/utils/boolean.js
@@ -1,0 +1,16 @@
+// Utility to convert various input types to boolean
+function convertirABoolean(valor) {
+  if (typeof valor === 'boolean') return valor;
+  if (typeof valor === 'string') {
+    const lower = valor.toLowerCase();
+    if (lower === 'true' || lower === '1' || lower === 'activo') return true;
+    if (lower === 'false' || lower === '0' || lower === 'inactivo') return false;
+  }
+  if (typeof valor === 'number') {
+    if (valor === 0) return false;
+    if (valor === 1) return true;
+  }
+  return true;
+}
+
+module.exports = { convertirABoolean };


### PR DESCRIPTION
## Summary
- move convertirABoolean into shared backend/utils/boolean.js
- import shared convertirABoolean in CategoriaController and CategoriasRouter
- update tests to reference shared helper

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a75e60de288331a5fc1636a037ef03