### PR TITLE
feat: centralize Prisma client initialization

### DIFF
--- a/backend/config/prisma.js
+++ b/backend/config/prisma.js
@@ -1,0 +1,17 @@
+const { PrismaClient } = require('@prisma/client');
+
+let prisma;
+
+function getPrismaClient() {
+  if (!prisma) {
+    try {
+      prisma = new PrismaClient();
+    } catch (error) {
+      console.error('Failed to initialize PrismaClient:', error);
+      prisma = null;
+    }
+  }
+  return prisma;
+}
+
+module.exports = getPrismaClient();

--- a/backend/controllers/CampanaController.js
+++ b/backend/controllers/CampanaController.js
@@ -1,7 +1,6 @@
-const { PrismaClient } = require('@prisma/client');
 const fs = require('fs');
 const path = require('path');
-const prisma = new PrismaClient();
+const prisma = require('../config/prisma');
 
 // Obtener campañas con productos
 const getCampanas = async (req, res) => {

--- a/backend/controllers/CategoriaController.js
+++ b/backend/controllers/CategoriaController.js
@@ -1,11 +1,5 @@
-const { PrismaClient } = require("@prisma/client");
 const { convertirABoolean } = require("../utils/boolean");
-let prisma;
-try {
-  prisma = new PrismaClient();
-} catch (e) {
-  prisma = null;
-}
+const prisma = require('../config/prisma');
 
 // Obtener todas las categorías
 const getCategorias = async (req, res) => {

--- a/backend/controllers/ProductoController.js
+++ b/backend/controllers/ProductoController.js
@@ -1,5 +1,4 @@
-const { PrismaClient } = require('@prisma/client');
-const prisma = new PrismaClient();
+const prisma = require('../config/prisma');
 
 // Obtener todos los productos
 const getAllProductos = async (req, res) => {

--- a/backend/index.js
+++ b/backend/index.js
@@ -3,7 +3,7 @@ const express = require('express');
 const cors = require('cors');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
-const { PrismaClient } = require('@prisma/client');
+const prisma = require('./config/prisma');
 const ProductosRoutes = require('./routes/ProductosRouter');
 const CategoriasRoutes = require('./routes/CategoriasRouter');
 const CampanaRouter = require('./routes/CampanaRouter');
@@ -11,7 +11,6 @@ const adminMiddleware = require('./middleware/adminMiddleware');
 const path = require('path');
 
 // --- INICIALIZACIONES ---
-const prisma = new PrismaClient();
 const app = express();
 const PORT = process.env.PORT || 3000;
 

--- a/backend/routes/CategoriasRouter.js
+++ b/backend/routes/CategoriasRouter.js
@@ -2,15 +2,13 @@ const express = require('express');
 const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
-const { PrismaClient } = require('@prisma/client');
+const prisma = require('../config/prisma');
 const {
   getCategorias,
   getCategoriaById,
   createCategoria,
   updateCategoria
 } = require('../controllers/CategoriaController');
-
-const prisma = new PrismaClient();
 const router = express.Router();
 const uploadDir = path.join(__dirname, '..', 'uploads');
 

--- a/backend/tests/convertirABoolean.test.js
+++ b/backend/tests/convertirABoolean.test.js
@@ -1,3 +1,4 @@
+jest.mock('../config/prisma', () => ({ $use: jest.fn() }));
 const { convertirABoolean } = require('../utils/boolean');
 
 describe('convertirABoolean', () => {


### PR DESCRIPTION
## Summary
- add shared Prisma client with initialization error handling
- refactor controllers and routes to use shared Prisma client
- mock Prisma client in unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a761a8cae083319fab52718fe770d3