### PR TITLE
refactor: centralize prisma client

### DIFF
--- a/backend/config/prisma.js
+++ b/backend/config/prisma.js
@@ -1,17 +1,6 @@
 const { PrismaClient } = require('@prisma/client');
 
-let prisma;
+// Create a single PrismaClient instance and export it for reuse
+const prisma = new PrismaClient();
 
-function getPrismaClient() {
-  if (!prisma) {
-    try {
-      prisma = new PrismaClient();
-    } catch (error) {
-      console.error('Failed to initialize PrismaClient:', error);
-      prisma = null;
-    }
-  }
-  return prisma;
-}
-
-module.exports = getPrismaClient();
+module.exports = prisma;

--- a/backend/tests/convertirABoolean.test.js
+++ b/backend/tests/convertirABoolean.test.js
@@ -1,3 +1,4 @@
+// Mock Prisma client to avoid database connections during tests
 jest.mock('../config/prisma', () => ({ $use: jest.fn() }));
 const { convertirABoolean } = require('../utils/boolean');
 


### PR DESCRIPTION
## Summary
- expose a single PrismaClient instance via `config/prisma.js`
- ensure tests mock the shared Prisma client module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a768e06e148331a4ce956e690388fd