### PR TITLE
feat: add non-admin home route

### DIFF
--- a/frontend/src/components/login/Login.vue
+++ b/frontend/src/components/login/Login.vue
@@ -40,10 +40,10 @@ const login = async () => {
 
     const decodedToken = jwtDecode(token);
 
-      if (decodedToken.rol === 'Administrador') {
+    if (decodedToken.rol === 'Administrador') {
       router.push('/dashboard');
     } else {
-      router.push('/'); 
+      router.push('/inicio');
     }
 
   } catch (error) {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -15,8 +15,9 @@ import UserForm from "../views/admin/UserForm.vue";
 
 const routes = [
   { path: "/login", name: "Login", component: Login },
+  { path: "/inicio", name: "Inicio", component: DashboardIndex, meta: { requiresAuth: true } },
 
-  { path: "/", redirect: "/dashboard", meta: { requiresAuth: true } },
+  { path: "/", redirect: "/inicio", meta: { requiresAuth: true } },
 
   {
     path: "/dashboard",
@@ -111,8 +112,11 @@ router.beforeEach((to, from, next) => {
 
   // CASO 2: El usuario YA está logueado Y está intentando ir a la página de login
   if (to.path === "/login" && token) {
-    // Lo mandamos a la página de inicio para que no vea el login de nuevo
-    return next("/");
+    // Lo mandamos a la página correspondiente según su rol
+    if (decodedToken && decodedToken.rol === "Administrador") {
+      return next("/dashboard");
+    }
+    return next("/inicio");
   }
 
   // CASO 3: La ruta requiere rol de administrador y el usuario no lo tiene


### PR DESCRIPTION
## Summary
- add `/inicio` route for authenticated non-admin users
- send non-privileged users to `/inicio` after login

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_68a76b26d6988331887c9d308107eba0