### PR TITLE
Refine admin role checks in router

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -112,17 +112,16 @@ router.beforeEach((to, from, next) => {
 
   // CASO 2: El usuario YA está logueado Y está intentando ir a la página de login
   if (to.path === "/login" && token) {
-    // Lo mandamos a la página correspondiente según su rol
     if (decodedToken && decodedToken.rol === "Administrador") {
-      return next("/dashboard");
+      return next("/");
     }
-    return next("/inicio");
+    return next();
   }
 
   // CASO 3: La ruta requiere rol de administrador y el usuario no lo tiene
   if (to.meta.requiresAdmin) {
     if (!decodedToken || decodedToken.rol !== "Administrador") {
-      alert("Acceso no autorizado");
+      localStorage.removeItem("authToken");
       return next("/login");
     }
   }


### PR DESCRIPTION
## Summary
- Decode auth token and redirect admins away from login
- Drop token when non-admin accesses admin route

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a76c5f3d8483319b59ae529c1a1bde