### PR TITLE
Use environment base URL for API calls

### DIFF
--- a/frontend/src/components/campanas/Campana.vue
+++ b/frontend/src/components/campanas/Campana.vue
@@ -62,7 +62,7 @@
                 :src="campana.imagenUrl 
                   ? (campana.imagenUrl.startsWith('http') 
                       ? campana.imagenUrl 
-                      : `http://localhost:3000${campana.imagenUrl}`) 
+                      : `${BASE}${campana.imagenUrl}`)
                   : placeholder" 
                 alt="Imagen campaña" 
                 class="w-full h-full object-cover"

--- a/frontend/src/components/campanas/useCampana.js
+++ b/frontend/src/components/campanas/useCampana.js
@@ -2,8 +2,9 @@ import { ref, computed, onMounted } from 'vue'
 import axios from 'axios'
 import Swal from 'sweetalert2'
 
-const API_URL = 'http://localhost:3000/api/campanas'
-const API_PRODUCTOS = 'http://localhost:3000/api/productos'
+const BASE = import.meta.env.VITE_API_URL || 'http://localhost:3000'
+const API_URL = `${BASE}/api/campanas`
+const API_PRODUCTOS = `${BASE}/api/productos`
 
 export default function useCampana() {
   const filtro = ref('')
@@ -225,7 +226,7 @@ export default function useCampana() {
     editando.value = true
     formulario.value = { ...campana, imagen: null }
     previewImage.value = campana.imagenUrl
-      ? `http://localhost:3000${campana.imagenUrl}`
+      ? `${BASE}${campana.imagenUrl}`
       : null
     productosSeleccionados.value = campana.productos || []
     modalAbierto.value = true
@@ -243,6 +244,7 @@ export default function useCampana() {
   }
 
   return {
+    BASE,
     filtro,
     placeholder,
     modalAbierto,

--- a/frontend/src/components/categorias/useCategorias.js
+++ b/frontend/src/components/categorias/useCategorias.js
@@ -12,6 +12,8 @@ export default function useCategorias() {
   const paginaActual = ref(1);
   const categoriasPorPagina = 5;
   const previewImage = ref(null);
+
+  const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
   
   // Formulario
   const form = ref({
@@ -112,7 +114,6 @@ export default function useCategorias() {
     try {
       console.log('🔍 Obteniendo categorías...');
       
-      const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
       const url = `${baseUrl}/api/categorias`;
       
       const response = await fetch(url, {
@@ -170,9 +171,8 @@ export default function useCategorias() {
         formData.append('imagen', form.value.imagen);
       }
 
-      const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
-      const url = editando.value 
-        ? `${baseUrl}/api/categorias/${form.value.id}` 
+      const url = editando.value
+        ? `${baseUrl}/api/categorias/${form.value.id}`
         : `${baseUrl}/api/categorias`;
       
       const method = editando.value ? 'PUT' : 'POST';
@@ -216,7 +216,6 @@ export default function useCategorias() {
           error.value = null;
 
           try {
-            const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
             const response = await fetch(`${baseUrl}/api/categorias/${categoria.id}`, {
               method: 'DELETE',
               headers: {
@@ -243,7 +242,6 @@ export default function useCategorias() {
   error.value = null;
 
   try {
-    const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
     const response = await fetch(`${baseUrl}/api/categorias/${categoria.id}/estado`, {
       method: 'PATCH',
       headers: {

--- a/frontend/src/components/login/Login.vue
+++ b/frontend/src/components/login/Login.vue
@@ -6,6 +6,8 @@ import axios from 'axios';
 import { useRouter } from 'vue-router';
 import { jwtDecode } from 'jwt-decode';
 
+const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
 const router = useRouter(); // Y esta
 
 // --- Variables reactivas ---
@@ -30,7 +32,7 @@ const registro = ref({
 const login = async () => {
   errorMessage.value = '';
   try {
-    const response = await axios.post('http://localhost:3000/auth/login', {
+    const response = await axios.post(`${baseUrl}/auth/login`, {
       cedula: cedula.value,
       contrasena: password.value,
     });
@@ -59,7 +61,7 @@ const login = async () => {
 const register = async () => {
   errorMessage.value = '';
   try {
-    await axios.post('http://localhost:3000/usuarios', registro.value);
+    await axios.post(`${baseUrl}/usuarios`, registro.value);
     
     alert('¡Registro exitoso! Ahora puedes iniciar sesión.');
     closeModal();

--- a/frontend/src/components/productos/Productos.vue
+++ b/frontend/src/components/productos/Productos.vue
@@ -10,6 +10,7 @@ export default {
     const productos = ref([]);
     const categoriaNombre = ref('');
     const loading = ref(false);
+    const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
     // Paginación
     const paginaActual = ref(1);
@@ -58,7 +59,7 @@ export default {
     const cargarProductos = async () => {
       try {
         const id = route.params.categoriaId;
-        const res = await fetch(`http://localhost:3000/api/productos/categoria/${id}`);
+        const res = await fetch(`${baseUrl}/api/productos/categoria/${id}`);
         if (res.ok) {
           const data = await res.json();
           productos.value = Array.isArray(data) ? data : data.productos || [];
@@ -93,7 +94,7 @@ export default {
         stock: producto.stock.toString(),
         imagen: null
       };
-      previewImage.value = producto.imagenUrl ? `http://localhost:3000${producto.imagenUrl}` : null;
+      previewImage.value = producto.imagenUrl ? `${baseUrl}${producto.imagenUrl}` : null;
       mostrarModal.value = true;
     };
 
@@ -138,8 +139,8 @@ export default {
         if (form.value.imagen) data.append('imagen', form.value.imagen);
 
         const url = editando.value
-          ? `http://localhost:3000/api/productos/${productoEditando.value.id}`
-          : 'http://localhost:3000/api/productos';
+          ? `${baseUrl}/api/productos/${productoEditando.value.id}`
+          : `${baseUrl}/api/productos`;
         const method = editando.value ? 'PUT' : 'POST';
 
         const res = await fetch(url, { method, body: data });
@@ -195,7 +196,7 @@ export default {
 
       try {
         loading.value = true;
-        const res = await fetch(`http://localhost:3000/api/productos/${producto.id}`, { method: 'DELETE' });
+        const res = await fetch(`${baseUrl}/api/productos/${producto.id}`, { method: 'DELETE' });
         const responseData = await res.json();
 
         if (res.ok) {
@@ -229,6 +230,7 @@ export default {
     };
 
     return {
+      baseUrl,
       productos,
       categoriaNombre,
       mostrarModal,
@@ -320,7 +322,7 @@ export default {
                 <td class="px-6 py-4 text-center">
                   <img 
                     v-if="producto.imagenUrl" 
-                    :src="`http://localhost:3000${producto.imagenUrl}`" 
+                    :src="`${baseUrl}${producto.imagenUrl}`"
                     class="w-16 h-16 object-cover rounded-lg mx-auto" 
                     @error="$event.target.style.display='none'"
                   />

--- a/frontend/src/views/admin/GestionProductos.vue
+++ b/frontend/src/views/admin/GestionProductos.vue
@@ -42,10 +42,11 @@ import { useRouter } from 'vue-router';
 
 const productos = ref([]);
 const router = useRouter();
+const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 async function cargarProductos() {
     try {
-        const response = await axios.get('http://localhost:3000/api/productos');
+        const response = await axios.get(`${baseUrl}/api/productos`);
         productos.value = response.data;
     } catch (error) {
         console.error("Error al cargar productos:", error);
@@ -61,7 +62,7 @@ async function eliminarProducto(id) {
 
     const token = localStorage.getItem('authToken');
     try {
-        await axios.delete(`http://localhost:3000/api/productos/${id}`, {
+        await axios.delete(`${baseUrl}/api/productos/${id}`, {
             headers: { 'Authorization': `Bearer ${token}` }
         });
         // Recargar la lista de productos para reflejar el cambio

--- a/frontend/src/views/admin/GestionUsuarios.vue
+++ b/frontend/src/views/admin/GestionUsuarios.vue
@@ -63,6 +63,7 @@ import { useRouter } from 'vue-router';
 
 const usuarios = ref([]);
 const router = useRouter();
+const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 // Lógica del modal para asignar puntos
 const showModal = ref(false);
@@ -86,7 +87,7 @@ const submitPoints = async () => {
   const token = localStorage.getItem('authToken');
   try {
     const response = await axios.post(
-      `http://localhost:3000/api/admin/usuarios/${selectedUser.value.id}/puntos`,
+      `${baseUrl}/api/admin/usuarios/${selectedUser.value.id}/puntos`,
       {
         puntos: pointsToAdd.value,
         descripcion: description.value,
@@ -117,7 +118,7 @@ async function eliminarUsuario(id) {
   }
   const token = localStorage.getItem('authToken');
   try {
-    await axios.delete(`http://localhost:3000/api/admin/usuarios/${id}`, {
+    await axios.delete(`${baseUrl}/api/admin/usuarios/${id}`, {
       headers: { 'Authorization': `Bearer ${token}` }
     });
     usuarios.value = usuarios.value.filter(u => u.id !== id);
@@ -132,7 +133,7 @@ async function eliminarUsuario(id) {
 onMounted(async () => {
   const token = localStorage.getItem('authToken');
   try {
-    const response = await axios.get('http://localhost:3000/api/admin/usuarios', {
+    const response = await axios.get(`${baseUrl}/api/admin/usuarios`, {
       headers: { 'Authorization': `Bearer ${token}` }
     });
     usuarios.value = response.data;

--- a/frontend/src/views/admin/ProductForm.vue
+++ b/frontend/src/views/admin/ProductForm.vue
@@ -45,6 +45,7 @@ import { useRouter, useRoute } from 'vue-router';
 
 const router = useRouter();
 const route = useRoute(); // Para acceder a los parámetros de la ruta, como el ID
+const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 const categorias = ref([]);
 const producto = ref({
@@ -61,7 +62,7 @@ const isEditing = computed(() => !!route.params.id);
 // Cargar las categorías
 onMounted(async () => {
   try {
-    const response = await axios.get('http://localhost:3000/api/categorias');
+    const response = await axios.get(`${baseUrl}/api/categorias`);
     categorias.value = response.data;
   } catch (error) {
     console.error("Error al cargar categorías:", error);
@@ -70,7 +71,7 @@ onMounted(async () => {
   // Si estamos en modo edición, cargar los datos del producto
   if (isEditing.value) {
     try {
-      const response = await axios.get(`http://localhost:3000/api/productos/${route.params.id}`);
+      const response = await axios.get(`${baseUrl}/api/productos/${route.params.id}`);
       producto.value = response.data;
     } catch (error) {
       console.error("Error al cargar el producto para editar:", error);
@@ -84,13 +85,13 @@ const guardarProducto = async () => {
   try {
     if (isEditing.value) {
       // Si estamos editando, usamos el método PUT
-      await axios.put(`http://localhost:3000/api/productos/${route.params.id}`, producto.value, {
+      await axios.put(`${baseUrl}/api/productos/${route.params.id}`, producto.value, {
         headers: { 'Authorization': `Bearer ${token}` }
       });
       alert('¡Producto actualizado con éxito!');
     } else {
       // Si no, usamos el método POST para crear
-      await axios.post('http://localhost:3000/api/productos', producto.value, {
+      await axios.post(`${baseUrl}/api/productos`, producto.value, {
         headers: { 'Authorization': `Bearer ${token}` }
       });
       alert('¡Producto creado con éxito!');

--- a/frontend/src/views/admin/UserForm.vue
+++ b/frontend/src/views/admin/UserForm.vue
@@ -64,6 +64,7 @@ import { useRouter, useRoute } from 'vue-router';
 
 const router = useRouter();
 const route = useRoute();
+const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 const usuario = ref({
     nombreCompleto: '',
@@ -83,7 +84,7 @@ onMounted(async () => {
     if (isEditing.value) {
         const token = localStorage.getItem('authToken');
         try {
-            const response = await axios.get(`http://localhost:3000/api/admin/usuarios/${route.params.id}`, {
+            const response = await axios.get(`${baseUrl}/api/admin/usuarios/${route.params.id}`, {
                 headers: { 'Authorization': `Bearer ${token}` }
             });
             // Asignamos los datos
@@ -108,7 +109,7 @@ const guardarUsuario = async () => {
         if (isEditing.value) {
             // Lógica de Actualización
             await axios.put(
-                `http://localhost:3000/api/admin/usuarios/${route.params.id}`,
+                `${baseUrl}/api/admin/usuarios/${route.params.id}`,
                 datosParaEnviar,
                 { headers: { 'Authorization': `Bearer ${token}` } }
             );
@@ -120,7 +121,7 @@ const guardarUsuario = async () => {
                 return;
             }
             await axios.post(
-                'http://localhost:3000/usuarios',
+                `${baseUrl}/usuarios`,
                 datosParaEnviar
             );
             alert('¡Usuario creado con éxito!');


### PR DESCRIPTION
## Summary
- replace hardcoded localhost URLs with import.meta.env.VITE_API_URL and fallback to default
- centralize base URL handling across components and admin views

## Testing
- `npm test` (frontend) *(fails: Missing script)*
- `npm test` (backend)`

------
https://chatgpt.com/codex/tasks/task_e_68a77e8f12d48331b822d0b43d8fdaca