### PR TITLE
feat: centralize API client with axios

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,0 +1,26 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3000',
+});
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('authToken');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response && error.response.status === 401) {
+      localStorage.removeItem('authToken');
+      window.location = '/login';
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default api;

--- a/frontend/src/components/campanas/useCampana.js
+++ b/frontend/src/components/campanas/useCampana.js
@@ -1,10 +1,9 @@
 import { ref, computed, onMounted } from 'vue'
-import axios from 'axios'
+import api from '../../api/client'
 import Swal from 'sweetalert2'
 
-const BASE = import.meta.env.VITE_API_URL || 'http://localhost:3000'
-const API_URL = `${BASE}/api/campanas`
-const API_PRODUCTOS = `${BASE}/api/productos`
+const API_URL = `/api/campanas`
+const API_PRODUCTOS = `/api/productos`
 
 export default function useCampana() {
   const filtro = ref('')
@@ -85,7 +84,7 @@ export default function useCampana() {
   // Cargar campañas
   const cargarCampanas = async () => {
     try {
-      const { data } = await axios.get(API_URL)
+      const { data } = await api.get(API_URL)
       campanas.value = data
     } catch (err) {
       console.error('Error cargando campañas:', err)
@@ -95,7 +94,7 @@ export default function useCampana() {
   // Cargar productos
   const cargarProductos = async () => {
     try {
-      const { data } = await axios.get(API_PRODUCTOS)
+      const { data } = await api.get(API_PRODUCTOS)
       productos.value = data
     } catch (err) {
       console.error('Error cargando productos:', err)
@@ -143,9 +142,9 @@ export default function useCampana() {
       }
 
       if (editando.value) {
-        await axios.put(`${API_URL}/${formulario.value.id}`, formData)
+        await api.put(`${API_URL}/${formulario.value.id}`, formData)
       } else {
-        await axios.post(API_URL, formData)
+        await api.post(API_URL, formData)
       }
 
       await cargarCampanas()
@@ -176,7 +175,7 @@ export default function useCampana() {
     if (!result.isConfirmed) return
 
     try {
-      await axios.delete(`${API_URL}/${campana.id}`)
+      await api.delete(`${API_URL}/${campana.id}`)
       await cargarCampanas()
       Swal.fire('Eliminado', 'La campaña fue eliminada correctamente', 'success')
     } catch (err) {

--- a/frontend/src/components/login/Login.vue
+++ b/frontend/src/components/login/Login.vue
@@ -2,11 +2,10 @@
 
 <script setup>
 import { ref, onMounted, onBeforeUnmount } from "vue";
-import axios from 'axios';
+import api from '../../api/client';
 import { useRouter } from 'vue-router';
 import { jwtDecode } from 'jwt-decode';
 
-const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 const router = useRouter(); // Y esta
 
@@ -32,7 +31,7 @@ const registro = ref({
 const login = async () => {
   errorMessage.value = '';
   try {
-    const response = await axios.post(`${baseUrl}/auth/login`, {
+    const response = await api.post(`/auth/login`, {
       cedula: cedula.value,
       contrasena: password.value,
     });
@@ -61,7 +60,7 @@ const login = async () => {
 const register = async () => {
   errorMessage.value = '';
   try {
-    await axios.post(`${baseUrl}/usuarios`, registro.value);
+    await api.post(`/usuarios`, registro.value);
     
     alert('¡Registro exitoso! Ahora puedes iniciar sesión.');
     closeModal();

--- a/frontend/src/views/admin/GestionProductos.vue
+++ b/frontend/src/views/admin/GestionProductos.vue
@@ -37,16 +37,15 @@
 
 <script setup>
 import { ref, onMounted } from 'vue';
-import axios from 'axios';
+import api from '../../api/client';
 import { useRouter } from 'vue-router';
 
 const productos = ref([]);
 const router = useRouter();
-const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 async function cargarProductos() {
     try {
-        const response = await axios.get(`${baseUrl}/api/productos`);
+        const response = await api.get(`/api/productos`);
         productos.value = response.data;
     } catch (error) {
         console.error("Error al cargar productos:", error);
@@ -60,11 +59,8 @@ function editarProducto(id) {
 async function eliminarProducto(id) {
     if (!confirm('¿Estás seguro de que quieres eliminar este producto?')) return;
 
-    const token = localStorage.getItem('authToken');
     try {
-        await axios.delete(`${baseUrl}/api/productos/${id}`, {
-            headers: { 'Authorization': `Bearer ${token}` }
-        });
+        await api.delete(`/api/productos/${id}`);
         // Recargar la lista de productos para reflejar el cambio
         await cargarProductos();
     } catch (error) {

--- a/frontend/src/views/admin/GestionUsuarios.vue
+++ b/frontend/src/views/admin/GestionUsuarios.vue
@@ -58,12 +58,11 @@
 
 <script setup>
 import { ref, onMounted } from 'vue';
-import axios from 'axios';
+import api from '../../api/client';
 import { useRouter } from 'vue-router';
 
 const usuarios = ref([]);
 const router = useRouter();
-const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 // Lógica del modal para asignar puntos
 const showModal = ref(false);
@@ -84,16 +83,12 @@ const closeModal = () => {
 
 const submitPoints = async () => {
   if (!selectedUser.value) return;
-  const token = localStorage.getItem('authToken');
   try {
-    const response = await axios.post(
-      `${baseUrl}/api/admin/usuarios/${selectedUser.value.id}/puntos`,
+    const response = await api.post(
+      `/api/admin/usuarios/${selectedUser.value.id}/puntos`,
       {
         puntos: pointsToAdd.value,
         descripcion: description.value,
-      },
-      {
-        headers: { 'Authorization': `Bearer ${token}` }
       }
     );
     const userIndex = usuarios.value.findIndex(u => u.id === selectedUser.value.id);
@@ -116,11 +111,8 @@ async function eliminarUsuario(id) {
   if (!confirm('¿Estás seguro de que quieres eliminar este usuario? Esta acción es irreversible.')) {
     return;
   }
-  const token = localStorage.getItem('authToken');
   try {
-    await axios.delete(`${baseUrl}/api/admin/usuarios/${id}`, {
-      headers: { 'Authorization': `Bearer ${token}` }
-    });
+    await api.delete(`/api/admin/usuarios/${id}`);
     usuarios.value = usuarios.value.filter(u => u.id !== id);
     alert('Usuario eliminado con éxito.');
   } catch (error) {
@@ -131,11 +123,8 @@ async function eliminarUsuario(id) {
 
 // Cargar los usuarios cuando el componente se monta
 onMounted(async () => {
-  const token = localStorage.getItem('authToken');
   try {
-    const response = await axios.get(`${baseUrl}/api/admin/usuarios`, {
-      headers: { 'Authorization': `Bearer ${token}` }
-    });
+    const response = await api.get(`/api/admin/usuarios`);
     usuarios.value = response.data;
   } catch (error) {
     console.error("No tienes permiso o hubo un error:", error);

--- a/frontend/src/views/admin/ProductForm.vue
+++ b/frontend/src/views/admin/ProductForm.vue
@@ -40,12 +40,11 @@
 
 <script setup>
 import { ref, onMounted, computed } from 'vue';
-import axios from 'axios';
+import api from '../../api/client';
 import { useRouter, useRoute } from 'vue-router';
 
 const router = useRouter();
 const route = useRoute(); // Para acceder a los parámetros de la ruta, como el ID
-const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 const categorias = ref([]);
 const producto = ref({
@@ -62,7 +61,7 @@ const isEditing = computed(() => !!route.params.id);
 // Cargar las categorías
 onMounted(async () => {
   try {
-    const response = await axios.get(`${baseUrl}/api/categorias`);
+    const response = await api.get(`/api/categorias`);
     categorias.value = response.data;
   } catch (error) {
     console.error("Error al cargar categorías:", error);
@@ -71,7 +70,7 @@ onMounted(async () => {
   // Si estamos en modo edición, cargar los datos del producto
   if (isEditing.value) {
     try {
-      const response = await axios.get(`${baseUrl}/api/productos/${route.params.id}`);
+      const response = await api.get(`/api/productos/${route.params.id}`);
       producto.value = response.data;
     } catch (error) {
       console.error("Error al cargar el producto para editar:", error);
@@ -81,19 +80,14 @@ onMounted(async () => {
 });
 
 const guardarProducto = async () => {
-  const token = localStorage.getItem('authToken');
   try {
     if (isEditing.value) {
       // Si estamos editando, usamos el método PUT
-      await axios.put(`${baseUrl}/api/productos/${route.params.id}`, producto.value, {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      await api.put(`/api/productos/${route.params.id}`, producto.value);
       alert('¡Producto actualizado con éxito!');
     } else {
       // Si no, usamos el método POST para crear
-      await axios.post(`${baseUrl}/api/productos`, producto.value, {
-        headers: { 'Authorization': `Bearer ${token}` }
-      });
+      await api.post(`/api/productos`, producto.value);
       alert('¡Producto creado con éxito!');
     }
     router.push('/dashboard/productos'); // Redirige a la lista de productos

--- a/frontend/src/views/admin/UserForm.vue
+++ b/frontend/src/views/admin/UserForm.vue
@@ -59,12 +59,11 @@
 
 <script setup>
 import { ref, onMounted, computed } from 'vue';
-import axios from 'axios';
+import api from '../../api/client';
 import { useRouter, useRoute } from 'vue-router';
 
 const router = useRouter();
 const route = useRoute();
-const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 const usuario = ref({
     nombreCompleto: '',
@@ -82,11 +81,8 @@ const isEditing = computed(() => !!route.params.id);
 
 onMounted(async () => {
     if (isEditing.value) {
-        const token = localStorage.getItem('authToken');
         try {
-            const response = await axios.get(`${baseUrl}/api/admin/usuarios/${route.params.id}`, {
-                headers: { 'Authorization': `Bearer ${token}` }
-            });
+            const response = await api.get(`/api/admin/usuarios/${route.params.id}`);
             // Asignamos los datos
             const userData = response.data;
             usuario.value = {
@@ -102,16 +98,14 @@ onMounted(async () => {
 });
 
 const guardarUsuario = async () => {
-    const token = localStorage.getItem('authToken');
     const datosParaEnviar = { ...usuario.value };
 
     try {
         if (isEditing.value) {
             // Lógica de Actualización
-            await axios.put(
-                `${baseUrl}/api/admin/usuarios/${route.params.id}`,
-                datosParaEnviar,
-                { headers: { 'Authorization': `Bearer ${token}` } }
+            await api.put(
+                `/api/admin/usuarios/${route.params.id}`,
+                datosParaEnviar
             );
             alert('¡Usuario actualizado con éxito!');
         } else {
@@ -120,8 +114,8 @@ const guardarUsuario = async () => {
                 alert('Para crear un usuario, se necesita una contraseña.');
                 return;
             }
-            await axios.post(
-                `${baseUrl}/usuarios`,
+            await api.post(
+                `/usuarios`,
                 datosParaEnviar
             );
             alert('¡Usuario creado con éxito!');


### PR DESCRIPTION
## Summary
- add axios API client with base URL, auth header, and interceptors
- migrate components to use shared client instead of direct axios

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a781d57f7c8331b2ffcf80010d37b9