### PR TITLE
feat: add carrito y pedidos

### DIFF
--- a/backend/controllers/CarritoController.js
+++ b/backend/controllers/CarritoController.js
@@ -1,0 +1,101 @@
+const prisma = require('../config/prisma');
+
+// Obtener items del carrito por usuario
+const getCarritoByUsuario = async (req, res) => {
+  try {
+    const { usuarioId } = req.params;
+    if (isNaN(usuarioId)) {
+      return res.status(400).json({ error: 'ID de usuario inválido' });
+    }
+
+    const items = await prisma.carrito.findMany({
+      where: { usuarioId: parseInt(usuarioId) },
+      include: { producto: true }
+    });
+
+    res.json(items);
+  } catch (error) {
+    console.error('Error al obtener carrito:', error);
+    res.status(500).json({ error: 'Error al obtener carrito' });
+  }
+};
+
+// Agregar item al carrito (o incrementar si ya existe)
+const addItem = async (req, res) => {
+  try {
+    const { usuarioId, productoId, cantidad } = req.body;
+    const uid = parseInt(usuarioId);
+    const pid = parseInt(productoId);
+    const qty = parseInt(cantidad) || 1;
+
+    if (isNaN(uid) || isNaN(pid) || isNaN(qty) || qty < 1) {
+      return res.status(400).json({ error: 'Datos inválidos' });
+    }
+
+    const item = await prisma.carrito.upsert({
+      where: { usuarioId_productoId: { usuarioId: uid, productoId: pid } },
+      update: { cantidad: { increment: qty } },
+      create: { usuarioId: uid, productoId: pid, cantidad: qty }
+    });
+
+    res.status(201).json(item);
+  } catch (error) {
+    console.error('Error al agregar al carrito:', error);
+    res.status(500).json({ error: 'Error al agregar al carrito' });
+  }
+};
+
+// Actualizar cantidad de un item del carrito
+const updateItem = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { cantidad } = req.body;
+    const cid = parseInt(id);
+    const qty = parseInt(cantidad);
+
+    if (isNaN(cid) || isNaN(qty) || qty < 1) {
+      return res.status(400).json({ error: 'Datos inválidos' });
+    }
+
+    const item = await prisma.carrito.update({
+      where: { id: cid },
+      data: { cantidad: qty }
+    });
+
+    res.json(item);
+  } catch (error) {
+    console.error('Error al actualizar carrito:', error);
+    if (error.code === 'P2025') {
+      return res.status(404).json({ error: 'Item no encontrado' });
+    }
+    res.status(500).json({ error: 'Error al actualizar carrito' });
+  }
+};
+
+// Eliminar item del carrito
+const deleteItem = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const cid = parseInt(id);
+    if (isNaN(cid)) {
+      return res.status(400).json({ error: 'ID inválido' });
+    }
+
+    await prisma.carrito.delete({ where: { id: cid } });
+    res.json({ message: 'Item eliminado del carrito' });
+  } catch (error) {
+    console.error('Error al eliminar del carrito:', error);
+    if (error.code === 'P2025') {
+      return res.status(404).json({ error: 'Item no encontrado' });
+    }
+    res.status(500).json({ error: 'Error al eliminar del carrito' });
+  }
+};
+
+module.exports = {
+  getCarritoByUsuario,
+  addItem,
+  updateItem,
+  deleteItem
+};
+

--- a/backend/controllers/PedidoController.js
+++ b/backend/controllers/PedidoController.js
@@ -1,0 +1,108 @@
+const prisma = require('../config/prisma');
+
+// Crear pedido a partir de detalles
+const crearPedido = async (req, res) => {
+  try {
+    const { usuarioId, detalles } = req.body;
+    const uid = parseInt(usuarioId);
+    if (isNaN(uid) || !Array.isArray(detalles) || detalles.length === 0) {
+      return res.status(400).json({ error: 'Datos inválidos' });
+    }
+
+    let total = 0;
+    const detallesData = [];
+
+    for (const d of detalles) {
+      const pid = parseInt(d.productoId);
+      const qty = parseInt(d.cantidad);
+      if (isNaN(pid) || isNaN(qty) || qty < 1) continue;
+
+      const producto = await prisma.producto.findUnique({ where: { id: pid } });
+      if (!producto) continue;
+      const puntosUnitarios = producto.precioPuntos;
+      total += puntosUnitarios * qty;
+      detallesData.push({ productoId: pid, cantidad: qty, puntosUnitarios });
+    }
+
+    if (detallesData.length === 0) {
+      return res.status(400).json({ error: 'Detalles inválidos' });
+    }
+
+    const pedido = await prisma.pedido.create({
+      data: {
+        usuarioId: uid,
+        totalPuntos: total,
+        detalles: { create: detallesData }
+      },
+      include: { detalles: true }
+    });
+
+    // Limpiar carrito del usuario
+    await prisma.carrito.deleteMany({ where: { usuarioId: uid } });
+
+    res.status(201).json(pedido);
+  } catch (error) {
+    console.error('Error al crear pedido:', error);
+    res.status(500).json({ error: 'Error al crear pedido' });
+  }
+};
+
+// Aprobar pedido por un administrador
+const aprobarPedido = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { adminId } = req.body;
+    const pid = parseInt(id);
+    const aid = parseInt(adminId);
+    if (isNaN(pid) || isNaN(aid)) {
+      return res.status(400).json({ error: 'Datos inválidos' });
+    }
+
+    const pedido = await prisma.pedido.update({
+      where: { id: pid },
+      data: {
+        estado: 'Aprobado',
+        aprobadoPorAdminId: aid,
+        fechaAprobacion: new Date()
+      }
+    });
+
+    await prisma.notificacion.create({
+      data: {
+        titulo: 'Pedido aprobado',
+        mensaje: `Tu pedido #${pedido.id} ha sido aprobado`,
+        usuarioId: pedido.usuarioId,
+        pedidoId: pedido.id
+      }
+    });
+
+    res.json({ message: 'Pedido aprobado', pedido });
+  } catch (error) {
+    console.error('Error al aprobar pedido:', error);
+    if (error.code === 'P2025') {
+      return res.status(404).json({ error: 'Pedido no encontrado' });
+    }
+    res.status(500).json({ error: 'Error al aprobar pedido' });
+  }
+};
+
+// Obtener todos los pedidos
+const getPedidos = async (req, res) => {
+  try {
+    const pedidos = await prisma.pedido.findMany({
+      include: { detalles: { include: { producto: true } }, usuario: true },
+      orderBy: { id: 'desc' }
+    });
+    res.json(pedidos);
+  } catch (error) {
+    console.error('Error al obtener pedidos:', error);
+    res.status(500).json({ error: 'Error al obtener pedidos' });
+  }
+};
+
+module.exports = {
+  crearPedido,
+  aprobarPedido,
+  getPedidos
+};
+

--- a/backend/index.js
+++ b/backend/index.js
@@ -7,6 +7,8 @@ const ProductosRoutes = require('./routes/ProductosRouter');
 const CategoriasRoutes = require('./routes/CategoriasRouter');
 const CampanaRouter = require('./routes/CampanaRouter');
 const UsuariosRouter = require('./routes/UsuariosRouter');
+const CarritoRouter = require('./routes/CarritoRouter');
+const PedidoRouter = require('./routes/PedidoRouter');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -21,6 +23,8 @@ app.use('/api/productos', ProductosRoutes);
 app.use('/api/categorias', CategoriasRoutes);
 app.use('/api/campanas', CampanaRouter);
 app.use('/', UsuariosRouter);
+app.use('/api/carrito', CarritoRouter);
+app.use('/api/pedidos', PedidoRouter);
 
 app.listen(PORT, () => {
   console.log(`Servidor corriendo en el puerto ${PORT}`);

--- a/backend/routes/CarritoRouter.js
+++ b/backend/routes/CarritoRouter.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const {
+  getCarritoByUsuario,
+  addItem,
+  updateItem,
+  deleteItem
+} = require('../controllers/CarritoController');
+
+const router = express.Router();
+
+router.get('/:usuarioId', getCarritoByUsuario);
+router.post('/', addItem);
+router.put('/:id', updateItem);
+router.delete('/:id', deleteItem);
+
+module.exports = router;
+

--- a/backend/routes/PedidoRouter.js
+++ b/backend/routes/PedidoRouter.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const {
+  crearPedido,
+  aprobarPedido,
+  getPedidos
+} = require('../controllers/PedidoController');
+
+const router = express.Router();
+
+router.get('/', getPedidos);
+router.post('/', crearPedido);
+router.put('/:id/aprobar', aprobarPedido);
+
+module.exports = router;
+

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -5,17 +5,20 @@ import { jwtDecode } from "jwt-decode";
 import Login from "../components/login/Login.vue";
 import Dashboard from "../components/layouts/Dashboard.vue";
 import DashboardIndex from "../views/admin/DashboardIndex.vue";
-import GestionUsuarios from "../views/admin/GestionUsuarios.vue"; 
+import GestionUsuarios from "../views/admin/GestionUsuarios.vue";
 import Categorias from "../components/categorias/Categorias.vue";
 import Productos from "../components/productos/Productos.vue";
 import Campana from "../components/campanas/Campana.vue";
 import ProductForm from "../views/admin/ProductForm.vue";
 import GestionProductos from "../views/admin/GestionProductos.vue";
 import UserForm from "../views/admin/UserForm.vue";
+import Carrito from "../views/Carrito.vue";
+import PedidosAdmin from "../views/admin/Pedidos.vue";
 
 const routes = [
   { path: "/login", name: "Login", component: Login },
   { path: "/inicio", name: "Inicio", component: DashboardIndex, meta: { requiresAuth: true } },
+  { path: "/carrito", name: "Carrito", component: Carrito, meta: { requiresAuth: true } },
 
   { path: "/", redirect: "/inicio", meta: { requiresAuth: true } },
 
@@ -81,6 +84,11 @@ const routes = [
         name: "EditarUsuario",
         component: UserForm,
         props: true,
+      },
+      {
+        path: "pedidos",
+        name: "GestionPedidos",
+        component: PedidosAdmin,
       },
     ],
   },

--- a/frontend/src/views/Carrito.vue
+++ b/frontend/src/views/Carrito.vue
@@ -1,0 +1,64 @@
+<script setup>
+import { ref, onMounted } from 'vue';
+import axios from 'axios';
+import { jwtDecode } from 'jwt-decode';
+
+const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+const token = localStorage.getItem('authToken');
+let userId = null;
+if (token) {
+  try {
+    const dec = jwtDecode(token);
+    userId = dec.id;
+  } catch (e) {
+    console.error('Token inválido');
+  }
+}
+
+const items = ref([]);
+const cantidades = ref({});
+
+const cargar = async () => {
+  if (!userId) return;
+  const res = await axios.get(`${baseUrl}/api/carrito/${userId}`);
+  items.value = res.data;
+  cantidades.value = Object.fromEntries(res.data.map(i => [i.id, i.cantidad]));
+};
+
+const actualizar = async (item) => {
+  await axios.put(`${baseUrl}/api/carrito/${item.id}`, { cantidad: cantidades.value[item.id] });
+  await cargar();
+};
+
+const eliminar = async (item) => {
+  await axios.delete(`${baseUrl}/api/carrito/${item.id}`);
+  await cargar();
+};
+
+const crearPedido = async () => {
+  const detalles = items.value.map(i => ({ productoId: i.productoId, cantidad: i.cantidad }));
+  if (detalles.length === 0) return;
+  await axios.post(`${baseUrl}/api/pedidos`, { usuarioId: userId, detalles });
+  await cargar();
+};
+
+onMounted(cargar);
+</script>
+
+<template>
+  <div class="p-4">
+    <h1 class="text-2xl mb-4">Carrito</h1>
+    <div v-if="items.length === 0">No hay productos en el carrito.</div>
+    <div v-for="item in items" :key="item.id" class="flex items-center gap-2 mb-2">
+      <span class="flex-1">{{ item.producto?.nombre }}</span>
+      <input type="number" min="1" v-model.number="cantidades[item.id]" class="border w-16" />
+      <button @click="actualizar(item)" class="bg-blue-500 text-white px-2 py-1">Actualizar</button>
+      <button @click="eliminar(item)" class="bg-red-500 text-white px-2 py-1">Eliminar</button>
+    </div>
+    <button @click="crearPedido" class="mt-4 bg-green-500 text-white px-4 py-2" :disabled="items.length === 0">
+      Crear Pedido
+    </button>
+  </div>
+</template>
+

--- a/frontend/src/views/admin/Pedidos.vue
+++ b/frontend/src/views/admin/Pedidos.vue
@@ -1,0 +1,45 @@
+<script setup>
+import { ref, onMounted } from 'vue';
+import axios from 'axios';
+import { jwtDecode } from 'jwt-decode';
+
+const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+const token = localStorage.getItem('authToken');
+let adminId = null;
+if (token) {
+  try {
+    const dec = jwtDecode(token);
+    adminId = dec.id;
+  } catch (e) {
+    console.error('Token inválido');
+  }
+}
+
+const pedidos = ref([]);
+
+const cargar = async () => {
+  const res = await axios.get(`${baseUrl}/api/pedidos`);
+  pedidos.value = res.data;
+};
+
+const aprobar = async (pedido) => {
+  await axios.put(`${baseUrl}/api/pedidos/${pedido.id}/aprobar`, { adminId });
+  await cargar();
+};
+
+onMounted(cargar);
+</script>
+
+<template>
+  <div class="p-4">
+    <h1 class="text-2xl mb-4">Pedidos</h1>
+    <div v-for="p in pedidos" :key="p.id" class="border p-2 mb-2">
+      <div>ID: {{ p.id }} - Estado: {{ p.estado }}</div>
+      <ul class="ml-4 list-disc">
+        <li v-for="d in p.detalles" :key="d.id">{{ d.producto?.nombre }} x {{ d.cantidad }}</li>
+      </ul>
+      <button v-if="p.estado !== 'Aprobado'" @click="aprobar(p)" class="mt-2 bg-green-500 text-white px-2 py-1">Aprobar</button>
+    </div>
+  </div>
+</template>
+


### PR DESCRIPTION
## Summary
- add carrito controller and routes for managing items
- implement pedido creation/approval with notifications
- expose carrito and pedidos UI in frontend

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a784f8a7f08331afc4f1514d68028d