### PR TITLE
feat: protect critical routes and send auth token

### DIFF
--- a/backend/routes/CampanaRouter.js
+++ b/backend/routes/CampanaRouter.js
@@ -10,6 +10,7 @@ const {
   asignarProducto,
   quitarProducto
 } = require('../controllers/CampanaController');
+const authMiddleware = require('../middleware/authMiddleware');
 const adminMiddleware = require('../middleware/adminMiddleware');
 
 const router = express.Router();
@@ -21,10 +22,9 @@ if (!fs.existsSync(uploadsDir)) {
   console.log('📁 Directorio uploads creado:', uploadsDir);
 }
 
-
 const storage = multer.diskStorage({
   destination: (req, file, cb) => {
-    cb(null, 'uploads/') 
+    cb(null, 'uploads/')
   },
   filename: (req, file, cb) => {
     const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9);
@@ -42,12 +42,12 @@ const fileFilter = (req, file, cb) => {
   }
 };
 
-const upload = multer({ 
+const upload = multer({
   storage,
   fileFilter,
   limits: {
-    fileSize: 5 * 1024 * 1024, 
-    files: 1 
+    fileSize: 5 * 1024 * 1024,
+    files: 1
   }
 });
 
@@ -64,20 +64,20 @@ const handleMulterError = (err, req, res, next) => {
       return res.status(400).json({ error: 'Campo de archivo inesperado.' });
     }
   }
-  
+
   if (err.message === 'Solo se permiten archivos de imagen') {
     return res.status(400).json({ error: 'Solo se permiten archivos de imagen (JPG, PNG, GIF, etc.).' });
   }
-  
+
   next(err);
 };
 
 //  Rutas
 router.get('/', getCampanas);
-router.post('/', adminMiddleware, upload.single('imagen'), handleMulterError, createCampana);
-router.put('/:id', adminMiddleware, upload.single('imagen'), handleMulterError, updateCampana);
-router.delete('/:id', adminMiddleware, deleteCampana);
-router.post('/asignar-producto', adminMiddleware, asignarProducto);
-router.post('/quitar-producto', adminMiddleware, quitarProducto);
+router.post('/', authMiddleware, adminMiddleware, upload.single('imagen'), handleMulterError, createCampana);
+router.put('/:id', authMiddleware, adminMiddleware, upload.single('imagen'), handleMulterError, updateCampana);
+router.delete('/:id', authMiddleware, adminMiddleware, deleteCampana);
+router.post('/asignar-producto', authMiddleware, adminMiddleware, asignarProducto);
+router.post('/quitar-producto', authMiddleware, adminMiddleware, quitarProducto);
 
 module.exports = router;

--- a/backend/routes/CarritoRouter.js
+++ b/backend/routes/CarritoRouter.js
@@ -5,13 +5,13 @@ const {
   updateItem,
   deleteItem
 } = require('../controllers/CarritoController');
+const authMiddleware = require('../middleware/authMiddleware');
 
 const router = express.Router();
 
-router.get('/:usuarioId', getCarritoByUsuario);
-router.post('/', addItem);
-router.put('/:id', updateItem);
-router.delete('/:id', deleteItem);
+router.get('/:usuarioId', authMiddleware, getCarritoByUsuario);
+router.post('/', authMiddleware, addItem);
+router.put('/:id', authMiddleware, updateItem);
+router.delete('/:id', authMiddleware, deleteItem);
 
 module.exports = router;
-

--- a/backend/routes/CategoriasRouter.js
+++ b/backend/routes/CategoriasRouter.js
@@ -10,6 +10,7 @@ const {
   deleteCategoria,
   toggleEstadoCategoria,
 } = require('../controllers/CategoriaController');
+const authMiddleware = require('../middleware/authMiddleware');
 const adminMiddleware = require('../middleware/adminMiddleware');
 const router = express.Router();
 const uploadDir = path.join(__dirname, '..', 'uploads');
@@ -31,10 +32,10 @@ const storage = multer.diskStorage({
   }
 });
 
-const upload = multer({ 
+const upload = multer({
   storage,
   limits: {
-    fileSize: 5 * 1024 * 1024 
+    fileSize: 5 * 1024 * 1024
   },
   fileFilter: (req, file, cb) => {
     const allowedTypes = /jpeg|jpg|png|gif|webp/;
@@ -56,15 +57,15 @@ router.get('/', getCategorias);
 router.get('/:id', getCategoriaById);
 
 // Crear nueva categoría
-router.post('/', adminMiddleware, upload.single('imagen'), createCategoria);
+router.post('/', authMiddleware, adminMiddleware, upload.single('imagen'), createCategoria);
 
 // Actualizar categoría
-router.put('/:id', adminMiddleware, upload.single('imagen'), updateCategoria);
+router.put('/:id', authMiddleware, adminMiddleware, upload.single('imagen'), updateCategoria);
 
 // Eliminar categoría
-router.delete('/:id', adminMiddleware, deleteCategoria);
+router.delete('/:id', authMiddleware, adminMiddleware, deleteCategoria);
 
 // Activar/Desactivar categoría
-router.patch('/:id/estado', adminMiddleware, toggleEstadoCategoria);
+router.patch('/:id/estado', authMiddleware, adminMiddleware, toggleEstadoCategoria);
 
 module.exports = router;

--- a/backend/routes/PedidoRouter.js
+++ b/backend/routes/PedidoRouter.js
@@ -4,12 +4,13 @@ const {
   aprobarPedido,
   getPedidos
 } = require('../controllers/PedidoController');
+const authMiddleware = require('../middleware/authMiddleware');
+const adminMiddleware = require('../middleware/adminMiddleware');
 
 const router = express.Router();
 
-router.get('/', getPedidos);
-router.post('/', crearPedido);
-router.put('/:id/aprobar', aprobarPedido);
+router.get('/', authMiddleware, adminMiddleware, getPedidos);
+router.post('/', authMiddleware, crearPedido);
+router.put('/:id/aprobar', authMiddleware, adminMiddleware, aprobarPedido);
 
 module.exports = router;
-

--- a/backend/routes/ProductosRouter.js
+++ b/backend/routes/ProductosRouter.js
@@ -2,6 +2,8 @@ const express = require('express');
 const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
+const authMiddleware = require('../middleware/authMiddleware');
+const adminMiddleware = require('../middleware/adminMiddleware');
 
 // IMPORTANTE: Importar el controlador de PRODUCTOS, no de Campañas
 const {
@@ -30,7 +32,7 @@ const storage = multer.diskStorage({
   }
 });
 
-const upload = multer({ 
+const upload = multer({
   storage,
   fileFilter: (req, file, cb) => {
     if (file.mimetype.startsWith('image/')) {
@@ -40,7 +42,7 @@ const upload = multer({
     }
   },
   limits: {
-    fileSize: 5 * 1024 * 1024 
+    fileSize: 5 * 1024 * 1024
   }
 });
 
@@ -48,7 +50,7 @@ const upload = multer({
 router.get('/', getAllProductos);
 router.get('/categoria/:categoriaId', getProductosByCategoria);
 router.get('/:id', getProductoById);
-router.post('/', upload.single('imagen'), createProducto);
-router.put('/:id', upload.single('imagen'), updateProducto);
-router.delete('/:id', deleteProducto);
+router.post('/', authMiddleware, adminMiddleware, upload.single('imagen'), createProducto);
+router.put('/:id', authMiddleware, adminMiddleware, upload.single('imagen'), updateProducto);
+router.delete('/:id', authMiddleware, adminMiddleware, deleteProducto);
 module.exports = router;

--- a/backend/routes/UsuariosRouter.js
+++ b/backend/routes/UsuariosRouter.js
@@ -22,10 +22,10 @@ router.post('/auth/login', loginUsuario);
 router.get('/api/perfil', authMiddleware, getPerfil);
 
 // Acciones de administrador
-router.post('/api/admin/usuarios/:id/puntos', adminMiddleware, asignarPuntos);
-router.get('/api/admin/usuarios', adminMiddleware, getUsuarios);
-router.get('/api/admin/usuarios/:id', adminMiddleware, getUsuario);
-router.put('/api/admin/usuarios/:id', adminMiddleware, updateUsuario);
-router.delete('/api/admin/usuarios/:id', adminMiddleware, deleteUsuario);
+router.post('/api/admin/usuarios/:id/puntos', authMiddleware, adminMiddleware, asignarPuntos);
+router.get('/api/admin/usuarios', authMiddleware, adminMiddleware, getUsuarios);
+router.get('/api/admin/usuarios/:id', authMiddleware, adminMiddleware, getUsuario);
+router.put('/api/admin/usuarios/:id', authMiddleware, adminMiddleware, updateUsuario);
+router.delete('/api/admin/usuarios/:id', authMiddleware, adminMiddleware, deleteUsuario);
 
 module.exports = router;

--- a/frontend/src/components/categorias/useCategorias.js
+++ b/frontend/src/components/categorias/useCategorias.js
@@ -109,9 +109,8 @@ export default function useCategorias() {
 
   const obtenerCategorias = async () => {
     loading.value = true;
-    error.value = null;
-    
-    try {
+            error.value = null;
+            try {
       console.log('🔍 Obteniendo categorías...');
       
       const url = `${baseUrl}/api/categorias`;
@@ -120,8 +119,9 @@ export default function useCategorias() {
         method: 'GET',
         headers: {
           'Accept': 'application/json',
-          'Content-Type': 'application/json'
-        }
+          'Content-Type': 'application/json',
+                'Authorization': 'Bearer ' + token
+              }
       });
 
       console.log('📡 Respuesta recibida:', response.status, response.statusText);
@@ -177,8 +177,12 @@ export default function useCategorias() {
       
       const method = editando.value ? 'PUT' : 'POST';
 
+            const token = localStorage.getItem('authToken');
       const response = await fetch(url, {
         method: method,
+        headers: {
+          'Authorization': 'Bearer ' + token 
+        },
         body: formData
       });
 
@@ -214,13 +218,14 @@ export default function useCategorias() {
 
           loading.value = true;
           error.value = null;
-
-          try {
+            try {
+            const token = localStorage.getItem('authToken');
             const response = await fetch(`${baseUrl}/api/categorias/${categoria.id}`, {
               method: 'DELETE',
               headers: {
                 'Accept': 'application/json',
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer ' + token
               }
             });
 
@@ -242,11 +247,13 @@ export default function useCategorias() {
   error.value = null;
 
   try {
+    const token = localStorage.getItem('authToken');
     const response = await fetch(`${baseUrl}/api/categorias/${categoria.id}/estado`, {
       method: 'PATCH',
       headers: {
         'Accept': 'application/json',
-        'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + token
       }
     });
 

--- a/frontend/src/components/productos/Productos.vue
+++ b/frontend/src/components/productos/Productos.vue
@@ -143,7 +143,12 @@ export default {
           : `${baseUrl}/api/productos`;
         const method = editando.value ? 'PUT' : 'POST';
 
-        const res = await fetch(url, { method, body: data });
+        const token = localStorage.getItem('authToken');
+        const res = await fetch(url, {
+          method,
+          headers: { 'Authorization': 'Bearer ' + token },
+          body: data
+        });
         const responseData = await res.json();
 
         if (res.ok) {
@@ -196,7 +201,8 @@ export default {
 
       try {
         loading.value = true;
-        const res = await fetch(`${baseUrl}/api/productos/${producto.id}`, { method: 'DELETE' });
+        const token = localStorage.getItem('authToken');
+        const res = await fetch(`${baseUrl}/api/productos/${producto.id}`, { method: 'DELETE', headers: { 'Authorization': 'Bearer ' + token } });
         const responseData = await res.json();
 
         if (res.ok) {


### PR DESCRIPTION
## Summary
- guard cart, campaign, category, order, product and user admin routes with auth and admin middleware
- send JWT bearer token for protected category and product operations on the frontend

## Testing
- `npm test` (backend)
- `npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a784fd337883318740f4aad8d80bd5