### PR TITLE
Add test scaffolding for backend and frontend

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node'
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,7 @@
     "jest": "^30.0.5",
     "nodemon": "^3.1.10",
     "prisma": "^6.13.0",
-    "prisma-erd-generator": "^2.0.4"
+    "prisma-erd-generator": "^2.0.4",
+    "supertest": "^6.3.4"
   }
 }

--- a/backend/tests/categoriaController.test.js
+++ b/backend/tests/categoriaController.test.js
@@ -1,0 +1,24 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../config/prisma', () => ({
+  categoria: { findMany: jest.fn() }
+}));
+
+const prisma = require('../config/prisma');
+const CategoriasRouter = require('../routes/CategoriasRouter');
+
+describe('GET /api/categorias', () => {
+  it('devuelve lista de categorias', async () => {
+    const mockCategorias = [{ id: 1, nombre: 'cat1' }];
+    prisma.categoria.findMany.mockResolvedValue(mockCategorias);
+
+    const app = express();
+    app.use('/api/categorias', CategoriasRouter);
+
+    const res = await request(app).get('/api/categorias');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockCategorias);
+    expect(prisma.categoria.findMany).toHaveBeenCalled();
+  });
+});

--- a/backend/tests/productoController.test.js
+++ b/backend/tests/productoController.test.js
@@ -1,0 +1,24 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../config/prisma', () => ({
+  producto: { findMany: jest.fn() }
+}));
+
+const prisma = require('../config/prisma');
+const ProductosRouter = require('../routes/ProductosRouter');
+
+describe('GET /api/productos', () => {
+  it('devuelve lista de productos', async () => {
+    const mockProductos = [{ id: 1, nombre: 'prod1', categoriaId: 2 }];
+    prisma.producto.findMany.mockResolvedValue(mockProductos);
+
+    const app = express();
+    app.use('/api/productos', ProductosRouter);
+
+    const res = await request(app).get('/api/productos');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockProductos);
+    expect(prisma.producto.findMany).toHaveBeenCalled();
+  });
+});

--- a/backend/tests/usuarioController.test.js
+++ b/backend/tests/usuarioController.test.js
@@ -1,0 +1,46 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../config/prisma', () => ({
+  usuario: { findUnique: jest.fn() }
+}));
+
+jest.mock('bcryptjs', () => ({
+  compare: jest.fn()
+}));
+
+jest.mock('jsonwebtoken', () => ({
+  sign: jest.fn()
+}));
+
+const prisma = require('../config/prisma');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const UsuariosRouter = require('../routes/UsuariosRouter');
+
+describe('POST /auth/login', () => {
+  it('devuelve un token cuando las credenciales son válidas', async () => {
+    prisma.usuario.findUnique.mockResolvedValue({
+      id: 1,
+      contrasena: 'hashed',
+      rol: 'Administrador',
+      nombreCompleto: 'Admin'
+    });
+    bcrypt.compare.mockResolvedValue(true);
+    jwt.sign.mockReturnValue('token123');
+
+    const app = express();
+    app.use(express.json());
+    app.use('/', UsuariosRouter);
+
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ cedula: '1', contrasena: 'pwd' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBe('token123');
+    expect(prisma.usuario.findUnique).toHaveBeenCalled();
+    expect(bcrypt.compare).toHaveBeenCalledWith('pwd', 'hashed');
+    expect(jwt.sign).toHaveBeenCalled();
+  });
+});

--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env']
+};

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,8 @@
+export default {
+  testEnvironment: 'jsdom',
+  moduleFileExtensions: ['js', 'json', 'vue'],
+  transform: {
+    '^.+\\.vue$': '@vue/vue3-jest',
+    '^.+\\.js$': 'babel-jest'
+  }
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@iconify/vue": "^5.0.0",
@@ -22,6 +23,12 @@
     "jest": "^30.0.5",
     "vite": "^7.0.4",
     "vite-plugin-windicss": "^1.9.4",
-    "windicss": "^3.5.6"
+    "windicss": "^3.5.6",
+    "@vue/test-utils": "^2.4.4",
+    "@vue/vue3-jest": "^29.2.5",
+    "babel-jest": "^29.7.0",
+    "@babel/core": "^7.24.5",
+    "@babel/preset-env": "^7.24.5",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/frontend/tests/App.test.js
+++ b/frontend/tests/App.test.js
@@ -1,0 +1,9 @@
+import { mount } from '@vue/test-utils';
+import App from '../src/App.vue';
+
+describe('App.vue', () => {
+  it('renderiza el componente principal', () => {
+    const wrapper = mount(App, { global: { stubs: ['router-view'] } });
+    expect(wrapper.exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- configure backend Jest with Supertest-based controller tests
- set up frontend Jest with Vue Test Utils and basic App component test

## Testing
- `npm test` (backend) *(fails: Cannot find module 'supertest')*
- `npm test` (frontend) *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7855f28cc8331a9267334af726a21