### PR TITLE
Handle missing auth token when fetching categories

### DIFF
--- a/frontend/src/components/categorias/useCategorias.js
+++ b/frontend/src/components/categorias/useCategorias.js
@@ -112,16 +112,23 @@ export default function useCategorias() {
             error.value = null;
             try {
       console.log('🔍 Obteniendo categorías...');
-      
+
+      const token = localStorage.getItem('authToken');
+      if (!token) {
+        window.location = '/login';
+        loading.value = false;
+        return;
+      }
+
       const url = `${baseUrl}/api/categorias`;
-      
+
       const response = await fetch(url, {
         method: 'GET',
         headers: {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
-                'Authorization': 'Bearer ' + token
-              }
+          'Authorization': 'Bearer ' + token
+        }
       });
 
       console.log('📡 Respuesta recibida:', response.status, response.statusText);


### PR DESCRIPTION
## Summary
- retrieve auth token before fetching categories
- redirect to login when token is missing

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78f18f7888331bbd206d5928e4b20