### PR TITLE
feat: link users to cargos

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -54,22 +54,31 @@ app.post('/usuarios', async (req, res) => {
       create: { nombre: centroDeCostosNombre }, // Si no existe, lo creamos
     });
 
+    // Lógica para encontrar o crear el cargo
+    const cargoRecord = await prisma.cargos.upsert({
+      where: { nombre: cargo },
+      update: {}, // Si ya existe, no hacemos nada
+      create: { nombre: cargo }, // Si no existe, lo creamos
+    });
+
     // Crear el nuevo usuario en la base de datos
     const nuevoUsuario = await prisma.usuario.create({
       data: {
         cedula,
         nombreCompleto,
-        cargo,
         sede,
         email,
         contrasena: hashedPassword,
         rol,
-            centroDeCostos: {
-      connect: {
-        id: centroDeCostos.id, // Conéctate a un centro de costos con este ID
+        centroDeCostos: {
+          connect: {
+            id: centroDeCostos.id, // Conéctate a un centro de costos con este ID
+          },
+        },
+        cargos: {
+          connect: { id: cargoRecord.id },
+        },
       },
-    },
-  },
     });
 
     // Devolvemos el usuario creado (excluyendo la contraseña por seguridad)

--- a/frontend/src/components/login/Login.vue
+++ b/frontend/src/components/login/Login.vue
@@ -17,7 +17,7 @@ const errorMessage = ref("");
 // Objeto de registro con el campo "centroDeCostosNombre"
 const registro = ref({
   nombreCompleto: "",
-  cargo: "",
+  cargoNombre: "",
   sede: "",
   centroDeCostosNombre: "",
   email: "",
@@ -59,12 +59,15 @@ const login = async () => {
 const register = async () => {
   errorMessage.value = '';
   try {
-    await axios.post('http://localhost:3000/usuarios', registro.value);
-    
+    await axios.post('http://localhost:3000/usuarios', {
+      ...registro.value,
+      cargo: registro.value.cargoNombre
+    });
+
     alert('¡Registro exitoso! Ahora puedes iniciar sesión.');
     closeModal();
-    registro.value = { nombreCompleto: "", cargo: "", sede: "", centroDeCostosNombre: "", email: "", cedula: "", contrasena: "", rol: 'Empleado' };
-  
+    registro.value = { nombreCompleto: "", cargoNombre: "", sede: "", centroDeCostosNombre: "", email: "", cedula: "", contrasena: "", rol: 'Empleado' };
+
   } catch (error) {
      if (error.response) {
       errorMessage.value = error.response.data.message;
@@ -222,7 +225,7 @@ onMounted(() => {
           
           <div class="input-group">
             <label for="cargo-reg">Cargo</label>
-            <input type="text" id="cargo-reg" v-model="registro.cargo" placeholder="Ingresa tu cargo" required />
+            <input type="text" id="cargo-reg" v-model="registro.cargoNombre" placeholder="Ingresa tu cargo" required />
           </div>
           <div class="input-group">
             <label for="sede-reg">Sede</label>


### PR DESCRIPTION
## Summary
- link `POST /usuarios` to cargo records using Prisma upsert and relation connect
- send cargo name from Login component when registering

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a888e66f908331a35db3ab023e3f12