### PR TITLE
refactor: centralize error handling

### DIFF
--- a/backend/controllers/AdminDataController.js
+++ b/backend/controllers/AdminDataController.js
@@ -1,22 +1,23 @@
 const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
+const { InternalServerError } = require('../utils/ApiError');
 
 // Obtener todos los cargos
-exports.getCargos = async (req, res) => {
+exports.getCargos = async (req, res, next) => {
   try {
     const cargos = await prisma.cargos.findMany({ orderBy: { nombre: 'asc' } });
     res.json(cargos);
   } catch (error) {
-    res.status(500).json({ message: 'Error al obtener los cargos.' });
+    next(new InternalServerError('Error al obtener los cargos.'));
   }
 };
 
 // Obtener todos los centros de costos
-exports.getCentrosDeCostos = async (req, res) => {
+exports.getCentrosDeCostos = async (req, res, next) => {
   try {
     const centros = await prisma.centroDeCostos.findMany({ orderBy: { nombre: 'asc' } });
     res.json(centros);
   } catch (error) {
-    res.status(500).json({ message: 'Error al obtener los centros de costos.' });
+    next(new InternalServerError('Error al obtener los centros de costos.'));
   }
 };

--- a/backend/controllers/CampanaController.js
+++ b/backend/controllers/CampanaController.js
@@ -2,6 +2,7 @@ const { PrismaClient } = require('@prisma/client');
 const fs = require('fs');
 const path = require('path');
 const prisma = new PrismaClient();
+const { InternalServerError } = require('../utils/ApiError');
 
 // FUNCIÓN PARA CORREGIR LA ZONA HORARIA
 const adjustDate = (dateString) => {
@@ -14,7 +15,7 @@ const adjustDate = (dateString) => {
 };
 
 // Obtener campañas con productos
-const getCampanas = async (req, res) => {
+const getCampanas = async (req, res, next) => {
   try {
     const campanas = await prisma.campana.findMany({
       orderBy: { fechaCreacion: 'desc' },
@@ -23,11 +24,11 @@ const getCampanas = async (req, res) => {
     res.json(campanas);
   } catch (error) {
     console.error('Error al obtener campañas:', error);
-    res.status(500).json({ error: 'Error al obtener campañas' });
+    next(new InternalServerError('Error al obtener campañas'));
   }
 };
 
-const getCampanaById = async (req, res) => {
+const getCampanaById = async (req, res, next) => {
   const { id } = req.params;
   try {
     const campana = await prisma.campana.findUnique({
@@ -43,13 +44,13 @@ const getCampanaById = async (req, res) => {
     res.json(campana);
   } catch (error) {
     console.error(`Error al obtener la campaña ${id}:`, error);
-    res.status(500).json({ message: "Error interno del servidor." });
+    next(new InternalServerError('Error interno del servidor.'));
   }
 };
 
 
 // Crear campaña
-const createCampana = async (req, res) => {
+const createCampana = async (req, res, next) => {
   try {
     const { titulo, descripcion, fechaInicio, fechaFin, aprobada: aprobadaStr, puntos: puntosStr, descuento: descuentoStr, productosIds } = req.body;
     const imagenUrl = req.file ? `/uploads/${req.file.filename}` : null;
@@ -91,12 +92,12 @@ const createCampana = async (req, res) => {
     res.json(nueva);
   } catch (error) {
     console.error("Error al crear campaña:", error);
-    res.status(500).json({ error: 'Error al crear campaña' });
+    next(new InternalServerError('Error al crear campaña'));
   }
 };
 
 // Actualizar campaña
-const updateCampana = async (req, res) => {
+const updateCampana = async (req, res, next) => {
   try {
     const { id } = req.params;
     const campanaExistente = await prisma.campana.findUnique({
@@ -145,11 +146,11 @@ const updateCampana = async (req, res) => {
     res.json(actualizada);
   } catch (error) {
     console.error("Error al actualizar campaña:", error);
-    res.status(500).json({ error: 'Error al actualizar campaña' });
+    next(new InternalServerError('Error al actualizar campaña'));
   }
 };
 
-const deleteCampana = async (req, res) => {
+const deleteCampana = async (req, res, next) => {
   try {
     const { id } = req.params;
     
@@ -173,11 +174,11 @@ const deleteCampana = async (req, res) => {
     res.json({ message: 'Campaña eliminada correctamente' });
   } catch (error) {
     console.error('Error al eliminar campaña:', error);
-    res.status(500).json({ error: 'Error al eliminar campaña' });
+    next(new InternalServerError('Error al eliminar campaña'));
   }
 };
 
-const asignarProducto = async (req, res) => {
+const asignarProducto = async (req, res, next) => {
   try {
     const { campanaId, productoId } = req.body;
     if (!campanaId || !productoId) {
@@ -195,11 +196,11 @@ const asignarProducto = async (req, res) => {
     res.json(campana);
   } catch (error) {
     console.error('Error al asignar producto:', error);
-    res.status(500).json({ error: 'Error al asignar producto a campaña' });
+    next(new InternalServerError('Error al asignar producto a campaña'));
   }
 };
 
-const quitarProducto = async (req, res) => {
+const quitarProducto = async (req, res, next) => {
   try {
     const { campanaId, productoId } = req.body;
     if (!campanaId || !productoId) {
@@ -217,7 +218,7 @@ const quitarProducto = async (req, res) => {
     res.json(campana);
   } catch (error) {
     console.error('Error al quitar producto:', error);
-    res.status(500).json({ error: 'Error al quitar producto de campaña' });
+    next(new InternalServerError('Error al quitar producto de campaña'));
   }
 };
 

--- a/backend/controllers/CarritoController.js
+++ b/backend/controllers/CarritoController.js
@@ -2,9 +2,10 @@
 
 const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
+const { InternalServerError } = require('../utils/ApiError');
 
 // Obtener el carrito de un usuario
-exports.getCarrito = async (req, res) => {
+exports.getCarrito = async (req, res, next) => {
   const usuarioId = req.usuario.userId;
   try {
     const carritoItems = await prisma.carrito.findMany({
@@ -27,12 +28,12 @@ exports.getCarrito = async (req, res) => {
     res.json(carritoItems);
   } catch (error) {
     console.error('Error al obtener el carrito:', error);
-    res.status(500).json({ message: 'Error interno del servidor.' });
+    next(new InternalServerError('Error interno del servidor.'));
   }
 };
 
 // Agregar un producto al carrito
-exports.agregarAlCarrito = async (req, res) => {
+exports.agregarAlCarrito = async (req, res, next) => {
   const usuarioId = req.usuario.userId;
   const { productoId, cantidad } = req.body;
 
@@ -80,12 +81,12 @@ exports.agregarAlCarrito = async (req, res) => {
     }
   } catch (error) {
     console.error('Error al agregar al carrito:', error);
-    res.status(500).json({ message: 'Error interno del servidor.' });
+    next(new InternalServerError('Error interno del servidor.'));
   }
 };
 
 // Eliminar un producto del carrito
-exports.eliminarDelCarrito = async (req, res) => {
+exports.eliminarDelCarrito = async (req, res, next) => {
   const usuarioId = req.usuario.userId;
   const { productoId } = req.params;
 
@@ -108,6 +109,6 @@ exports.eliminarDelCarrito = async (req, res) => {
     res.json({ message: 'Producto eliminado del carrito.' });
   } catch (error) {
     console.error('Error al eliminar del carrito:', error);
-    res.status(500).json({ message: 'Error interno del servidor.' });
+    next(new InternalServerError('Error interno del servidor.'));
   }
 };

--- a/backend/controllers/CategoriaController.js
+++ b/backend/controllers/CategoriaController.js
@@ -2,6 +2,7 @@ const { PrismaClient } = require("@prisma/client");
 const fs = require('fs');
 const path = require('path');
 const prisma = new PrismaClient();
+const { InternalServerError } = require('../utils/ApiError');
 
 // Helper para convertir valores a booleano de forma segura
 const convertirABoolean = (valor) => {
@@ -14,7 +15,7 @@ const convertirABoolean = (valor) => {
 };
 
 // Obtener todas las categorías
-exports.getCategorias = async (req, res) => {
+exports.getCategorias = async (req, res, next) => {
   try {
     const categorias = await prisma.categoria.findMany({
       orderBy: { fechaCreacion: "desc" },
@@ -23,12 +24,12 @@ exports.getCategorias = async (req, res) => {
     res.json(categorias);
   } catch (error) {
     console.error("Error al obtener categorías:", error);
-    res.status(500).json({ message: "Error al obtener las categorías" });
+    next(new InternalServerError('Error al obtener las categorías'));
   }
 };
 
 // Obtener categoría por ID
-exports.getCategoriaById = async (req, res) => {
+exports.getCategoriaById = async (req, res, next) => {
   const { id } = req.params;
   try {
     const categoria = await prisma.categoria.findUnique({
@@ -39,12 +40,12 @@ exports.getCategoriaById = async (req, res) => {
     res.json(categoria);
   } catch (error) {
     console.error("Error al obtener categoría:", error);
-    res.status(500).json({ message: "Error al obtener la categoría" });
+    next(new InternalServerError('Error al obtener la categoría'));
   }
 };
 
 // Crear categoría
-exports.createCategoria = async (req, res) => {
+exports.createCategoria = async (req, res, next) => {
   const { nombre, descripcion } = req.body;
   try {
     if (!nombre || nombre.trim() === "") {
@@ -67,12 +68,12 @@ exports.createCategoria = async (req, res) => {
     res.status(201).json(nuevaCategoria);
   } catch (error) {
     console.error("Error al crear categoría:", error);
-    res.status(500).json({ error: "Error al crear la categoría" });
+    next(new InternalServerError('Error al crear la categoría'));
   }
 };
 
 // Actualizar categoría
-exports.updateCategoria = async (req, res) => {
+exports.updateCategoria = async (req, res, next) => {
   const { id } = req.params;
   const { nombre, descripcion, activo } = req.body;
   try {
@@ -97,12 +98,12 @@ exports.updateCategoria = async (req, res) => {
     res.json(categoriaActualizada);
   } catch (error) {
     console.error("Error al actualizar categoría:", error);
-    res.status(500).json({ error: "Error al actualizar la categoría" });
+    next(new InternalServerError('Error al actualizar la categoría'));
   }
 };
 
 // Eliminar categoría
-exports.deleteCategoria = async (req, res) => {
+exports.deleteCategoria = async (req, res, next) => {
   const { id } = req.params;
   try {
     const categoria = await prisma.categoria.findUnique({
@@ -128,12 +129,12 @@ exports.deleteCategoria = async (req, res) => {
     res.json({ message: "Categoría eliminada correctamente" });
   } catch (error) {
     console.error("Error al eliminar categoría:", error);
-    res.status(500).json({ error: "Error al eliminar la categoría" });
+    next(new InternalServerError('Error al eliminar la categoría'));
   }
 };
 
 // Activar / Desactivar categoría
-exports.toggleEstadoCategoria = async (req, res) => {
+exports.toggleEstadoCategoria = async (req, res, next) => {
   const { id } = req.params;
   try {
     const categoria = await prisma.categoria.findUnique({ where: { id: parseInt(id) } });
@@ -146,6 +147,6 @@ exports.toggleEstadoCategoria = async (req, res) => {
     res.json({ message: `Categoría ${categoriaActualizada.activo ? "activada" : "desactivada"}`, categoria: categoriaActualizada });
   } catch (error) {
     console.error("Error al cambiar estado de categoría:", error);
-    res.status(500).json({ error: "Error al cambiar el estado" });
+    next(new InternalServerError('Error al cambiar el estado'));
   }
 };

--- a/backend/controllers/DashboardController.js
+++ b/backend/controllers/DashboardController.js
@@ -1,8 +1,9 @@
 // backend/controllers/DashboardController.js
 const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
+const { InternalServerError } = require('../utils/ApiError');
 
-exports.getStats = async (req, res) => {
+exports.getStats = async (req, res, next) => {
   try {
     // 1. Conteo total de usuarios (solo empleados)
     const totalUsuarios = await prisma.usuario.count({
@@ -59,6 +60,6 @@ exports.getStats = async (req, res) => {
 
   } catch (error) {
     console.error("Error al obtener estadísticas del dashboard:", error);
-    res.status(500).json({ message: 'Error interno del servidor.' });
+    next(new InternalServerError('Error interno del servidor.'));
   }
 };

--- a/backend/controllers/HistorialController.js
+++ b/backend/controllers/HistorialController.js
@@ -1,10 +1,11 @@
 const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
+const { InternalServerError } = require('../utils/ApiError');
 
 /**
  * Obtiene el historial de puntos del usuario autenticado.
  */
-exports.getHistorial = async (req, res) => {
+exports.getHistorial = async (req, res, next) => {
   const usuarioId = req.usuario.userId;
 
   try {
@@ -16,6 +17,6 @@ exports.getHistorial = async (req, res) => {
     res.status(200).json(historial);
   } catch (error) {
     console.error("Error al obtener el historial de puntos:", error);
-    res.status(500).json({ message: "Error interno del servidor." });
+    next(new InternalServerError('Error interno del servidor.'));
   }
 };

--- a/backend/controllers/NotificacionController.js
+++ b/backend/controllers/NotificacionController.js
@@ -1,7 +1,8 @@
 const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
+const { InternalServerError } = require('../utils/ApiError');
 
-exports.getMisNotificaciones = async (req, res) => {
+exports.getMisNotificaciones = async (req, res, next) => {
   const usuarioId = req.usuario.userId;
   try {
     const notificaciones = await prisma.notificacion.findMany({
@@ -11,10 +12,10 @@ exports.getMisNotificaciones = async (req, res) => {
     });
     res.json(notificaciones);
   } catch (error) {
-    res.status(500).json({ message: 'Error al obtener notificaciones.' });
+    next(new InternalServerError('Error al obtener notificaciones.'));
   }
 };
-exports.getUnreadCount = async (req, res) => {
+exports.getUnreadCount = async (req, res, next) => {
   const usuarioId = req.usuario.userId;
   try {
     const count = await prisma.notificacion.count({
@@ -25,12 +26,12 @@ exports.getUnreadCount = async (req, res) => {
     });
     res.json({ count });
   } catch (error) {
-    res.status(500).json({ message: 'Error al obtener el conteo.' });
+    next(new InternalServerError('Error al obtener el conteo.'));
   }
 };
 
 // Marcar todas las notificaciones como leídas
-exports.markAllAsRead = async (req, res) => {
+exports.markAllAsRead = async (req, res, next) => {
   const usuarioId = req.usuario.userId;
   try {
     await prisma.notificacion.updateMany({
@@ -44,6 +45,6 @@ exports.markAllAsRead = async (req, res) => {
     });
     res.status(200).json({ message: 'Notificaciones marcadas como leídas.' });
   } catch (error) {
-    res.status(500).json({ message: 'Error al marcar las notificaciones.' });
+    next(new InternalServerError('Error al marcar las notificaciones.'));
   }
 };

--- a/backend/controllers/PerfilController.js
+++ b/backend/controllers/PerfilController.js
@@ -2,12 +2,13 @@
 
 const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
+const { InternalServerError } = require('../utils/ApiError');
 
 /**
  * Obtiene el perfil del usuario actualmente autenticado.
  * Se usa en los layouts para mostrar el nombre, puntos, etc.
  */
-exports.getPerfil = async (req, res) => {
+exports.getPerfil = async (req, res, next) => {
   try {
     const usuario = await prisma.usuario.findUnique({
       where: { id: req.usuario.userId },
@@ -33,6 +34,6 @@ exports.getPerfil = async (req, res) => {
     
   } catch (error) {
     console.error("Error al obtener perfil:", error);
-    res.status(500).json({ message: 'Error al obtener el perfil.' });
+    next(new InternalServerError('Error al obtener el perfil.'));
   }
 };

--- a/backend/controllers/ProductoController.js
+++ b/backend/controllers/ProductoController.js
@@ -1,8 +1,9 @@
 const { PrismaClient } = require('@prisma/client');
 const prisma = new PrismaClient();
+const { InternalServerError } = require('../utils/ApiError');
 
 // Obtener todos los productos
-const getAllProductos = async (req, res) => {
+const getAllProductos = async (req, res, next) => {
   try {
     const productos = await prisma.producto.findMany({
       include: { 
@@ -14,12 +15,12 @@ const getAllProductos = async (req, res) => {
     res.json(productos);
   } catch (error) {
     console.error("Error al obtener productos:", error);
-    res.status(500).json({ error: "Error al obtener productos" });
+    next(new InternalServerError('Error al obtener productos'));
   }
 };
 
 // Obtener productos por categoría
-const getProductosByCategoria = async (req, res) => {
+const getProductosByCategoria = async (req, res, next) => {
   try {
     const { categoriaId } = req.params;
     if (isNaN(categoriaId)) {
@@ -38,12 +39,12 @@ const getProductosByCategoria = async (req, res) => {
     res.json(productos);
   } catch (error) {
     console.error("Error al obtener productos por categoría:", error);
-    res.status(500).json({ error: "Error al obtener productos por categoría" });
+    next(new InternalServerError('Error al obtener productos por categoría'));
   }
 };
 
 // Crear producto
-const createProducto = async (req, res) => {
+const createProducto = async (req, res, next) => {
   try {
     const { nombre, descripcion, precioPuntos, stock, categoriaId } = req.body;
     const imagenUrl = req.file ? `/uploads/${req.file.filename}` : null;
@@ -96,12 +97,12 @@ const createProducto = async (req, res) => {
     res.status(201).json(nuevo);
   } catch (error) {
     console.error("Error al crear producto:", error);
-    res.status(500).json({ error: "Error al crear producto" });
+    next(new InternalServerError('Error al crear producto'));
   }
 };
 
 // Actualizar producto
-const updateProducto = async (req, res) => {
+const updateProducto = async (req, res, next) => {
   try {
     const { id } = req.params;
     const { nombre, descripcion, precioPuntos, stock, categoriaId } = req.body;
@@ -165,12 +166,12 @@ const updateProducto = async (req, res) => {
     res.json(actualizado);
   } catch (error) {
     console.error("Error al actualizar producto:", error);
-    res.status(500).json({ error: "Error al actualizar producto" });
+    next(new InternalServerError('Error al actualizar producto'));
   }
 };
 
 // Eliminar producto
-const deleteProducto = async (req, res) => {
+const deleteProducto = async (req, res, next) => {
   try {
     const { id } = req.params;
     if (isNaN(id)) {
@@ -206,7 +207,7 @@ const deleteProducto = async (req, res) => {
     res.json({ message: "Producto eliminado correctamente" });
   } catch (error) {
     console.error("Error al eliminar producto:", error);
-    res.status(500).json({ error: "Error al eliminar producto" });
+    next(new InternalServerError('Error al eliminar producto'));
   }
 };
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -18,6 +18,7 @@ const PerfilRouter = require('./routes/PerfilRouter');
 const HistorialRouter = require('./routes/HistorialRouter');
 const AdminDataRouter = require('./routes/AdminDataRouter');
 const DashboardRouter = require('./routes/DashboardRouter');
+const errorHandler = require('./middleware/errorHandler');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -43,6 +44,9 @@ app.use('/api/carrito', CarritoRouter);
 app.use('/api/historial', HistorialRouter);
 app.use('/api/admin-data', AdminDataRouter);
 app.use('/api/dashboard', DashboardRouter);
+
+// --- MIDDLEWARE DE MANEJO DE ERRORES ---
+app.use(errorHandler);
 
 
 // --- INICIO DEL SERVIDOR ---

--- a/backend/middleware/adminMiddleware.js
+++ b/backend/middleware/adminMiddleware.js
@@ -1,22 +1,30 @@
 // backend/middleware/adminMiddleware.js
 const jwt = require('jsonwebtoken');
+const {
+  UnauthorizedError,
+  ForbiddenError,
+} = require('../utils/ApiError');
 
 const adminMiddleware = (req, res, next) => {
   const authHeader = req.headers['authorization'];
   const token = authHeader && authHeader.split(' ')[1];
 
   if (!token) {
-    return res.status(401).json({ message: 'No se proveyó un token.' });
+    return next(new UnauthorizedError('No se proveyó un token.'));
   }
 
   jwt.verify(token, process.env.JWT_SECRET, (err, usuario) => {
     if (err) {
-      return res.status(403).json({ message: 'Token no válido.' });
+      return next(new ForbiddenError('Token no válido.'));
     }
 
     // ✅ ¡La verificación clave!
     if (usuario.rol !== 'Administrador') {
-      return res.status(403).json({ message: 'Acceso denegado. Se requiere rol de administrador.' });
+      return next(
+        new ForbiddenError(
+          'Acceso denegado. Se requiere rol de administrador.'
+        )
+      );
     }
 
     req.usuario = usuario;

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -1,13 +1,19 @@
 // backend/middleware/authMiddleware.js
 
 const jwt = require('jsonwebtoken');
+const {
+  UnauthorizedError,
+  ForbiddenError,
+} = require('../utils/ApiError');
 
 const authMiddleware = (req, res, next) => {
   const authHeader = req.headers['authorization'];
   const token = authHeader && authHeader.split(' ')[1]; // Formato: "Bearer TOKEN"
 
   if (!token) {
-    return res.status(401).json({ message: 'Acceso denegado. No se proveyó un token.' });
+    return next(
+      new UnauthorizedError('Acceso denegado. No se proveyó un token.')
+    );
   }
 
   try {
@@ -15,7 +21,7 @@ const authMiddleware = (req, res, next) => {
     req.usuario = decoded; // Añade los datos del token a la petición
     next(); // Continúa con la siguiente función
   } catch (error) {
-    res.status(403).json({ message: 'Token no válido o expirado.' });
+    next(new ForbiddenError('Token no válido o expirado.'));
   }
 };
 

--- a/backend/middleware/errorHandler.js
+++ b/backend/middleware/errorHandler.js
@@ -1,0 +1,13 @@
+const { ApiError, InternalServerError } = require('../utils/ApiError');
+
+const errorHandler = (err, req, res, next) => {
+  if (err instanceof ApiError) {
+    return res.status(err.statusCode).json({ error: err.message });
+  }
+
+  console.error(err);
+  const internalError = new InternalServerError();
+  res.status(internalError.statusCode).json({ error: internalError.message });
+};
+
+module.exports = errorHandler;

--- a/backend/utils/ApiError.js
+++ b/backend/utils/ApiError.js
@@ -1,0 +1,52 @@
+class ApiError extends Error {
+  constructor(statusCode, message) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}
+
+class BadRequestError extends ApiError {
+  constructor(message = 'Bad Request') {
+    super(400, message);
+  }
+}
+
+class UnauthorizedError extends ApiError {
+  constructor(message = 'Unauthorized') {
+    super(401, message);
+  }
+}
+
+class ForbiddenError extends ApiError {
+  constructor(message = 'Forbidden') {
+    super(403, message);
+  }
+}
+
+class NotFoundError extends ApiError {
+  constructor(message = 'Not Found') {
+    super(404, message);
+  }
+}
+
+class InternalServerError extends ApiError {
+  constructor(message = 'Internal Server Error') {
+    super(500, message);
+  }
+}
+
+class ConflictError extends ApiError {
+  constructor(message = 'Conflict') {
+    super(409, message);
+  }
+}
+
+module.exports = {
+  ApiError,
+  BadRequestError,
+  UnauthorizedError,
+  ForbiddenError,
+  NotFoundError,
+  InternalServerError,
+  ConflictError,
+};


### PR DESCRIPTION
## Summary
- add ApiError classes and a centralized error handler
- propagate errors from controllers via next instead of sending responses
- update auth and admin middlewares to emit ApiError

## Testing
- `cd backend && npm test >/tmp/test.log && tail -n 20 /tmp/test.log` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c20367ce9083318e764b93f396a5b8