### PR TITLE
Agregue campañas activas y modales de productos a la página de inicio

### DIFF
--- a/frontend/src/components/inicio/InicioNoL.vue
+++ b/frontend/src/components/inicio/InicioNoL.vue
@@ -14,16 +14,15 @@
             class="w-20 h-20 flex items-center justify-center rounded-full shadow-md bg-white border-2 transition group-hover:scale-110"
             :class="{ 'border-blue-400 scale-110': categoriaSeleccionadaId === cat.id }"
           >
-            <img v-if="cat.imagenUrl" :src="`${API_BASE_URL}${cat.imagenUrl}`" @error="handleImageError(cat)" class="w-full h-full object-cover rounded-full" />
-            <Icon v-else :icon="cat.icono || 'mdi:tag'" class="text-3xl text-blue-700" />
+            <Icon :icon="cat.icon" class="text-3xl text-blue-700" />
           </div>
-          <p class="mt-2 text-gray-700 font-medium">{{ cat.nombre }}</p>
+          <p class="mt-2 text-gray-700 font-medium capitalize">{{ cat.nombre }}</p>
         </div>
       </div>
     </section>
 
     <section v-if="categoriaSeleccionadaId" class="text-center space-y-12">
-        <h3 class="text-3xl font-extrabold text-black">Productos de {{ categoriaSeleccionadaNombre }}</h3>
+        <h3 class="text-3xl font-extrabold text-black capitalize">Productos de {{ categoriaSeleccionadaNombre }}</h3>
         <div v-if="loadingProductos" class="text-center">Cargando productos...</div>
         <div v-else-if="productosPaginados.length > 0">
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
@@ -37,7 +36,7 @@
                         <p class="text-sm text-gray-600 flex-1">{{ producto.descripcion || "Un producto increíble te espera." }}</p>
                     </div>
                     <div class="p-5 border-t flex justify-center">
-                        <button @click="verMas" class="px-5 py-2 bg-[#74B9E7] text-black font-medium rounded-lg hover:bg-[#FFB93B] transition">
+                        <button @click="verProducto(producto)" class="px-5 py-2 bg-[#74B9E7] text-black font-medium rounded-lg hover:bg-[#FFB93B] transition">
                             Ver más
                         </button>
                     </div>
@@ -54,11 +53,10 @@
         </div>
     </section>
 
-
     <section class="text-center space-y-12">
       <h3 class="text-3xl font-extrabold text-black">Destacados</h3>
       <div v-if="loading" class="text-center">Cargando...</div>
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
+      <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
         <div
           v-for="item in destacados"
           :key="item.id"
@@ -66,21 +64,15 @@
         >
           <div class="relative">
             <img :src="`${API_BASE_URL}${item.imagenUrl}`" @error="$event.target.src = 'https://placehold.co/400x300/e2e8f0/a0aec0?text=Producto'" alt="producto" class="h-48 w-full object-cover" />
-            <span
-              class="absolute top-3 left-3 bg-[#FFB93B] text-black text-xs font-semibold px-3 py-1 rounded-full shadow"
-            >
-              Destacado
-            </span>
-             <span class="absolute top-3 right-3 bg-blue-500 text-white text-sm font-semibold px-3 py-1 rounded-full shadow">{{ item.precioPuntos }} Pts</span>
+            <span class="absolute top-3 left-3 bg-[#FFB93B] text-black text-xs font-semibold px-3 py-1 rounded-full shadow">Destacado</span>
+            <span class="absolute top-3 right-3 bg-blue-500 text-white text-sm font-semibold px-3 py-1 rounded-full shadow">{{ item.precioPuntos }} Pts</span>
           </div>
           <div class="p-5 flex-1 flex flex-col">
             <h4 class="text-lg font-bold text-gray-800 mb-2">{{ item.nombre }}</h4>
-            <p class="text-sm text-gray-600 flex-1">
-              {{ item.descripcion || "Descubre esta novedad pensada para ti." }}
-            </p>
+            <p class="text-sm text-gray-600 flex-1">{{ item.descripcion || "Descubre esta novedad pensada para ti." }}</p>
           </div>
           <div class="p-5 border-t flex justify-center">
-            <button @click="verMas" class="px-5 py-2 bg-[#74B9E7] text-black font-medium rounded-lg hover:bg-[#FFB93B] transition">
+            <button @click="verProducto(item)" class="px-5 py-2 bg-[#74B9E7] text-black font-medium rounded-lg hover:bg-[#FFB93B] transition">
               Ver más
             </button>
           </div>
@@ -88,36 +80,140 @@
       </div>
     </section>
 
+    <section>
+      <h2 class="text-2xl font-bold text-center mb-8">Campañas Activas</h2>
+      <div v-if="loading" class="text-center">Cargando campañas...</div>
+      <div v-else-if="campanasActivas.length > 0" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 mb-6">
+        <div
+          v-for="campana in campanasActivas"
+          :key="campana.id"
+          class="bg-white shadow-md rounded-2xl p-6 flex flex-col justify-between hover:shadow-lg transition"
+        >
+          <div class="flex justify-between items-center mb-4">
+            <h3 class="text-lg font-semibold text-gray-800">{{ campana.titulo }}</h3>
+            <span class="px-3 py-1 text-xs rounded-full font-medium bg-yellow-400 text-black">Activa</span>
+          </div>
+          <p class="text-sm text-gray-600 mb-6">{{ campana.descripcion }}</p>
+          <button
+            class="bg-blue-400 text-white px-4 py-2 rounded-lg hover:bg-blue-500 transition self-end"
+            @click="verCampana(campana)"
+          >
+            Ver campaña
+          </button>
+        </div>
+      </div>
+       <div v-else class="text-center text-gray-500">
+        <p>No hay campañas activas en este momento.</p>
+      </div>
+    </section>
+
+    <div v-if="modalAbierto" class="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50 backdrop-blur-sm" @click="cerrarModal">
+      <div class="bg-white rounded-3xl shadow-2xl p-6 w-full max-w-lg relative transform transition-all scale-100" @click.stop>
+        <button class="absolute top-3 right-3 text-gray-400 hover:text-gray-600 transition" @click="cerrarModal">✕</button>
+        <div class="w-full flex justify-center mb-4">
+          <img v-if="campanaSeleccionada.imagenUrl" :src="`${API_BASE_URL}${campanaSeleccionada.imagenUrl}`" alt="Imagen campaña" class="rounded-xl shadow-md object-cover max-h-44 w-auto" />
+        </div>
+        <h3 class="text-2xl font-bold text-gray-800 mb-3 text-center">{{ campanaSeleccionada.titulo }}</h3>
+        <p class="text-gray-600 mb-4 text-center text-sm leading-relaxed">{{ campanaSeleccionada.descripcion }}</p>
+        <div class="flex justify-between text-xs text-gray-500 mb-4 border-t pt-2">
+          <p><strong>Inicio:</strong> {{ new Date(campanaSeleccionada.fechaInicio).toLocaleDateString() }}</p>
+          <p><strong>Fin:</strong> {{ new Date(campanaSeleccionada.fechaFin).toLocaleDateString() }}</p>
+        </div>
+        <div class="flex justify-around text-sm text-gray-700 mb-4">
+          <p class="bg-blue-100 text-blue-800 px-3 py-1 rounded-lg font-medium">Puntos: {{ campanaSeleccionada.puntos || "N/A" }}</p>
+          <p class="bg-green-100 text-green-800 px-3 py-1 rounded-lg font-medium">Descuento: {{ campanaSeleccionada.descuento ? campanaSeleccionada.descuento + "%" : "N/A" }}</p>
+        </div>
+        <h4 class="font-semibold text-gray-800 mb-2">Productos incluidos:</h4>
+        <ul class="list-disc list-inside text-sm text-gray-600 space-y-1 max-h-28 overflow-y-auto">
+          <li v-for="producto in campanaSeleccionada.productos" :key="producto.id">{{ producto.nombre }} - {{ producto.precioPuntos }} pts</li>
+          <li v-if="!campanaSeleccionada.productos || campanaSeleccionada.productos.length === 0">No hay productos asociados</li>
+        </ul>
+        <div class="flex justify-center mt-6">
+          <button class="bg-gradient-to-r from-blue-400 to-blue-600 text-white px-6 py-2 rounded-full shadow-md hover:shadow-lg hover:from-blue-500 hover:to-blue-700 transition" @click="participarCampana">
+            Participar en la campaña
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="productoModalAbierto" class="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50 backdrop-blur-sm" @click="cerrarProductoModal">
+      <div class="bg-white rounded-3xl shadow-2xl p-6 w-full max-w-lg relative transform transition-all scale-100" @click.stop>
+        <button class="absolute top-3 right-3 text-gray-400 hover:text-gray-600 transition" @click="cerrarProductoModal">✕</button>
+        <div class="w-full flex justify-center mb-4">
+          <img v-if="productoSeleccionado.imagenUrl" :src="`${API_BASE_URL}${productoSeleccionado.imagenUrl}`" alt="Imagen producto" class="rounded-xl shadow-md object-cover max-h-52 w-auto" />
+        </div>
+        <h3 class="text-2xl font-bold text-gray-800 mb-3 text-center">{{ productoSeleccionado.nombre }}</h3>
+        <p class="text-gray-600 mb-4 text-center text-sm leading-relaxed">{{ productoSeleccionado.descripcion || 'No hay descripción disponible para este producto.' }}</p>
+        <div class="text-center my-4">
+          <span class="text-2xl font-bold text-blue-600">{{ productoSeleccionado.precioPuntos }} Puntos</span>
+        </div>
+        <div class="flex justify-center mt-6">
+          <button class="bg-gradient-to-r from-blue-400 to-blue-600 text-white px-6 py-2 rounded-full shadow-md hover:shadow-lg hover:from-blue-500 hover:to-blue-700 transition" @click="iniciarSesionParaComprar">
+            Iniciar Sesión para Canjear
+          </button>
+        </div>
+      </div>
+    </div>
+
   </div>
 </template>
 
 <script setup>
+// ... (el script no necesita cambios, la solución es solo en el template)
 import { ref, computed, onMounted } from "vue";
 import { Icon } from "@iconify/vue";
 import Swal from "sweetalert2";
 import axios from 'axios';
+import { useRouter } from 'vue-router';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+const router = useRouter();
 
+const iconMap = {
+  'cocina': 'mdi:silverware-fork-knife',
+  'tecnologia': 'mdi:laptop',
+  'hogar': 'mdi:lamp',
+  'moda': 'mdi:tshirt-crew',
+  'deportes': 'mdi:weight-lifter',
+  'turismo': 'mdi:palm-tree'
+};
+
+// Refs para datos
 const categorias = ref([]);
 const productos = ref([]);
+const campanas = ref([]);
 const loading = ref(true);
 const loadingProductos = ref(false);
+
+// Refs para estado de la UI
 const categoriaSeleccionadaId = ref(null);
+const modalAbierto = ref(false);
+const campanaSeleccionada = ref({});
+const productoModalAbierto = ref(false);
+const productoSeleccionado = ref(null);
 
 // Paginación
 const paginaActual = ref(1);
-const productosPorPagina = 4; // Puedes ajustar este número
+const productosPorPagina = 4;
 
 const cargarDatos = async () => {
   loading.value = true;
   try {
-    const [resCategorias, resProductos] = await Promise.all([
+    const [resCategorias, resProductos, resCampanas] = await Promise.all([
       axios.get(`${API_BASE_URL}/api/categorias`),
-      axios.get(`${API_BASE_URL}/api/productos`)
+      axios.get(`${API_BASE_URL}/api/productos`),
+      axios.get(`${API_BASE_URL}/api/campanas`)
     ]);
-    categorias.value = resCategorias.data.filter(c => c.activo && c._count.productos > 0);
+    
+    categorias.value = resCategorias.data
+      .filter(c => c.activo && c._count.productos > 0)
+      .map(c => ({
+        ...c,
+        icon: iconMap[c.nombre.toLowerCase()] || 'mdi:tag-heart' 
+      }));
+
     productos.value = resProductos.data.filter(p => p.estado);
+    campanas.value = resCampanas.data;
   } catch (error) {
     console.error("Error al cargar datos:", error);
     Swal.fire('Error', 'No se pudieron cargar los datos de la tienda.', 'error');
@@ -130,19 +226,12 @@ onMounted(cargarDatos);
 
 const seleccionarCategoria = (id) => {
     if (categoriaSeleccionadaId.value === id) {
-        // Si se hace clic en la misma categoría, se deselecciona
         categoriaSeleccionadaId.value = null;
     } else {
         categoriaSeleccionadaId.value = id;
-        paginaActual.value = 1; // Resetea la página al cambiar de categoría
+        paginaActual.value = 1;
     }
 };
-
-// Función para manejar errores de carga de imagen y mostrar el icono
-const handleImageError = (category) => {
-  category.imagenUrl = null; // Elimina la URL de la imagen para que se renderice el icono
-};
-
 
 const productosFiltrados = computed(() => {
   if (!categoriaSeleccionadaId.value) return [];
@@ -155,7 +244,6 @@ const categoriaSeleccionadaNombre = computed(() => {
     return categoria ? categoria.nombre : '';
 });
 
-
 const totalPaginas = computed(() => Math.ceil(productosFiltrados.value.length / productosPorPagina));
 
 const productosPaginados = computed(() => {
@@ -164,21 +252,46 @@ const productosPaginados = computed(() => {
   return productosFiltrados.value.slice(inicio, fin);
 });
 
-
 const destacados = computed(() => {
   return [...productos.value]
     .sort((a, b) => b.precioPuntos - a.precioPuntos)
     .slice(0, 4);
 });
 
-const verMas = () => {
+const campanasActivas = computed(() => campanas.value.filter(c => c.aprobada));
+
+const verCampana = (campana) => {
+  campanaSeleccionada.value = campana;
+  modalAbierto.value = true;
+};
+const cerrarModal = () => (modalAbierto.value = false);
+
+const verProducto = (producto) => {
+  productoSeleccionado.value = producto;
+  productoModalAbierto.value = true;
+};
+
+const cerrarProductoModal = () => {
+  productoModalAbierto.value = false;
+};
+
+const iniciarSesionParaComprar = () => {
+  cerrarProductoModal();
   Swal.fire({
     icon: "info",
-    title: "Inicia sesión",
-    text: "Debes iniciar sesión para ver más detalles del producto.",
-    confirmButtonText: "Entendido",
-    confirmButtonColor: "#2563eb",
+    title: "Inicia sesión para continuar",
+    text: "Debes iniciar sesión para poder canjear este producto.",
+    confirmButtonText: "Ir a Iniciar Sesión",
+    showCancelButton: true,
+    cancelButtonText: "Cancelar"
+  }).then((result) => {
+    if (result.isConfirmed) {
+      router.push('/login');
+    }
   });
 };
 
+const participarCampana = () => {
+  iniciarSesionParaComprar();
+};
 </script>


### PR DESCRIPTION
Se introduce una nueva sección para mostrar campañas activas con detalles de los modals y se añaden modals de detalles de producto, tanto para productos destacados como para productos de categoría. Se refactoriza la gestión de iconos de categoría, se mejora el uso de mayúsculas en la interfaz de usuario y se actualizan las acciones de los botones para mostrar modals y solicitar el inicio de sesión para el canje. También se incluye una limpieza de código y pequeñas mejoras en la interfaz de usuario.