### PR TITLE
Improve backend error messaging with details

### DIFF
--- a/backend/controllers/AuthController.js
+++ b/backend/controllers/AuthController.js
@@ -56,7 +56,7 @@ const register = async (req, res) => {
             return res.status(409).json({ message: `El campo '${field}' ya está en uso.` });
         }
         console.error("Error al crear usuario:", error);
-        res.status(500).json({ message: 'Error interno del servidor al crear el usuario.' });
+        res.status(500).json({ message: 'No se pudo crear el usuario', details: error.message });
     }
 };
 
@@ -97,7 +97,7 @@ const login = async (req, res) => {
 
     } catch (error) {
         console.error("Error en el login:", error);
-        res.status(500).json({ message: 'Error interno del servidor.' });
+        res.status(500).json({ message: 'No se pudo iniciar sesión', details: error.message });
     }
 };
 
@@ -139,7 +139,7 @@ const forgotPassword = async (req, res) => {
         console.error("Error en forgotPassword:", error);
         // Limpiamos los tokens si algo sale mal
         await prisma.usuario.update({ where: { email }, data: { passwordResetToken: null, passwordResetExpires: null } });
-        res.status(500).json({ message: 'Error interno del servidor.' });
+        res.status(500).json({ message: 'No se pudo procesar la solicitud de recuperación de contraseña', details: error.message });
     }
 };
 
@@ -179,7 +179,7 @@ const resetPassword = async (req, res) => {
 
     } catch (error) {
         console.error("Error en resetPassword:", error);
-        res.status(500).json({ message: 'Error interno del servidor.' });
+        res.status(500).json({ message: 'No se pudo restablecer la contraseña', details: error.message });
     }
 };
 

--- a/backend/controllers/CampanaController.js
+++ b/backend/controllers/CampanaController.js
@@ -43,7 +43,7 @@ const getCampanaById = async (req, res) => {
     res.json(campana);
   } catch (error) {
     console.error(`Error al obtener la campaña ${id}:`, error);
-    res.status(500).json({ message: "Error interno del servidor." });
+    res.status(500).json({ message: 'No se pudo obtener la campaña', details: error.message });
   }
 };
 

--- a/backend/controllers/CarritoController.js
+++ b/backend/controllers/CarritoController.js
@@ -27,7 +27,7 @@ exports.getCarrito = async (req, res) => {
     res.json(carritoItems);
   } catch (error) {
     console.error('Error al obtener el carrito:', error);
-    res.status(500).json({ message: 'Error interno del servidor.' });
+    res.status(500).json({ message: 'No se pudo obtener el carrito', details: error.message });
   }
 };
 
@@ -80,7 +80,7 @@ exports.agregarAlCarrito = async (req, res) => {
     }
   } catch (error) {
     console.error('Error al agregar al carrito:', error);
-    res.status(500).json({ message: 'Error interno del servidor.' });
+    res.status(500).json({ message: 'No se pudo agregar el producto al carrito', details: error.message });
   }
 };
 
@@ -108,6 +108,6 @@ exports.eliminarDelCarrito = async (req, res) => {
     res.json({ message: 'Producto eliminado del carrito.' });
   } catch (error) {
     console.error('Error al eliminar del carrito:', error);
-    res.status(500).json({ message: 'Error interno del servidor.' });
+    res.status(500).json({ message: 'No se pudo eliminar el producto del carrito', details: error.message });
   }
 };

--- a/backend/controllers/DashboardController.js
+++ b/backend/controllers/DashboardController.js
@@ -59,6 +59,6 @@ exports.getStats = async (req, res) => {
 
   } catch (error) {
     console.error("Error al obtener estadísticas del dashboard:", error);
-    res.status(500).json({ message: 'Error interno del servidor.' });
+    res.status(500).json({ message: 'No se pudieron obtener las estadísticas del dashboard', details: error.message });
   }
 };

--- a/backend/controllers/HistorialController.js
+++ b/backend/controllers/HistorialController.js
@@ -16,6 +16,6 @@ exports.getHistorial = async (req, res) => {
     res.status(200).json(historial);
   } catch (error) {
     console.error("Error al obtener el historial de puntos:", error);
-    res.status(500).json({ message: "Error interno del servidor." });
+    res.status(500).json({ message: 'No se pudo obtener el historial de puntos', details: error.message });
   }
 };

--- a/backend/controllers/PedidoController.js
+++ b/backend/controllers/PedidoController.js
@@ -29,7 +29,7 @@ const getAllPedidos = async (req, res) => {
     });
   } catch (error) {
     console.error("Error al obtener pedidos:", error);
-    res.status(500).json({ message: 'Error interno del servidor.' });
+    res.status(500).json({ message: 'No se pudieron obtener los pedidos', details: error.message });
   }
 };
 
@@ -211,7 +211,7 @@ const getMisPedidos = async (req, res) => {
     res.json(pedidos);
   } catch (error) {
     console.error("Error al obtener mis pedidos:", error);
-    res.status(500).json({ message: 'Error interno del servidor.' });
+    res.status(500).json({ message: 'No se pudieron obtener tus pedidos', details: error.message });
   }
 };
 

--- a/backend/controllers/PerfilController.js
+++ b/backend/controllers/PerfilController.js
@@ -33,6 +33,6 @@ exports.getPerfil = async (req, res) => {
     
   } catch (error) {
     console.error("Error al obtener perfil:", error);
-    res.status(500).json({ message: 'Error al obtener el perfil.' });
+    res.status(500).json({ message: 'No se pudo obtener el perfil', details: error.message });
   }
 };

--- a/backend/controllers/UsuarioController.js
+++ b/backend/controllers/UsuarioController.js
@@ -57,7 +57,7 @@ exports.getAllUsuarios = async (req, res) => {
 
   } catch (error) {
     console.error("Error al obtener usuarios:", error);
-    res.status(500).json({ message: 'Error interno del servidor.' });
+    res.status(500).json({ message: 'No se pudieron obtener los usuarios', details: error.message });
   }
 };
 
@@ -87,7 +87,7 @@ exports.createUsuario = async (req, res) => {
             return res.status(409).json({ message: `El campo '${error.meta.target[0]}' ya está en uso.` });
         }
         console.error("Error al crear usuario:", error);
-        res.status(500).json({ message: 'Error interno del servidor.' });
+        res.status(500).json({ message: 'No se pudo crear el usuario', details: error.message });
     }
 };
 
@@ -210,7 +210,7 @@ exports.updateMiPerfil = async (req, res) => {
     if (error.code === 'P2002') {
       return res.status(409).json({ message: 'El email ya está en uso por otro usuario.' });
     }
-    res.status(500).json({ message: 'Error interno del servidor al actualizar el perfil.' });
+    res.status(500).json({ message: 'No se pudo actualizar el perfil', details: error.message });
   }
 };
 exports.ajustarPuntos = async (req, res) => {


### PR DESCRIPTION
## Summary
- Replace generic 500 responses in controllers with messages that describe the failed operation
- Include `error.message` details for easier debugging across login, pedidos, campañas, and more

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c32f7b9eac8331827e4a32ed35c6cc